### PR TITLE
feat(core): implement SchemaValidator domain service (MMNT-30)

### DIFF
--- a/packages/core/__tests__/services/schema-validator.spec.ts
+++ b/packages/core/__tests__/services/schema-validator.spec.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect } from 'vitest';
+import { SchemaValidator } from '../../src/services/schema-validator.js';
+import type {
+  IntermediateRepresentation,
+  ValidationResult,
+  ContextDefinition,
+  FlowDefinition,
+  ConnectionDefinition,
+  FrameDefinition,
+} from '../../src/ir/index.js';
+
+function makeMinimalContext(overrides: Partial<ContextDefinition> = {}): ContextDefinition {
+  return {
+    id: 'ctx-1',
+    name: 'TestContext',
+    aggregates: [],
+    domainServices: [],
+    commands: [],
+    events: [],
+    policies: [],
+    sagas: [],
+    valueObjects: [],
+    invariants: [],
+    ...overrides,
+  };
+}
+
+function makeMinimalIR(
+  overrides: Partial<IntermediateRepresentation> = {},
+): IntermediateRepresentation {
+  return {
+    contexts: [],
+    flows: [],
+    glossary: [],
+    relationships: [],
+    metadata: { name: 'test', version: '1.0.0' },
+    ...overrides,
+  };
+}
+
+function makeFrame(overrides: Partial<FrameDefinition> = {}): FrameDefinition {
+  return {
+    id: 'frame-1',
+    name: 'Frame 1',
+    contextEntries: [],
+    ...overrides,
+  };
+}
+
+describe('SchemaValidator', () => {
+  const validator = new SchemaValidator();
+
+  describe('SP-01', () => {
+    it('rejects unresolved context reference in flow', () => {
+      const ir = makeMinimalIR({
+        contexts: [makeMinimalContext({ id: 'ctx-1' })],
+        flows: [
+          {
+            id: 'flow-1',
+            name: 'Test Flow',
+            frames: [],
+            connections: [
+              {
+                id: 'conn-1',
+                sourceFrameId: 'frame-1',
+                targetContextId: 'ctx-nonexistent',
+                eventId: 'evt-1',
+                connectionType: 'crosses-to',
+                schemaContract: {
+                  eventType: 'SomeEvent',
+                  fields: [{ name: 'id', type: 'string', required: true }],
+                  relationshipType: 'partnership',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = validator.validate(ir);
+      expect(result.valid).toBe(false);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0].ruleId).toBe('SP-01');
+      expect(result.diagnostics[0].message).toContain('ctx-nonexistent');
+    });
+
+    it('accepts resolved context reference', () => {
+      const ir = makeMinimalIR({
+        contexts: [
+          makeMinimalContext({
+            id: 'ctx-target',
+            events: [{ id: 'evt-1', name: 'SomeEvent', fields: [] }],
+          }),
+        ],
+        flows: [
+          {
+            id: 'flow-1',
+            name: 'Test Flow',
+            frames: [],
+            connections: [
+              {
+                id: 'conn-1',
+                sourceFrameId: 'frame-1',
+                targetContextId: 'ctx-target',
+                eventId: 'evt-1',
+                connectionType: 'crosses-to',
+                schemaContract: {
+                  eventType: 'SomeEvent',
+                  fields: [{ name: 'id', type: 'string', required: true }],
+                  relationshipType: 'partnership',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = validator.validate(ir);
+      const sp01Diagnostics = result.diagnostics.filter((d) => d.ruleId === 'SP-01');
+      expect(sp01Diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe('SP-02', () => {
+    it('rejects unresolved event in crossing', () => {
+      const ir = makeMinimalIR({
+        contexts: [
+          makeMinimalContext({
+            id: 'ctx-target',
+            events: [{ id: 'evt-real', name: 'RealEvent', fields: [] }],
+          }),
+        ],
+        flows: [
+          {
+            id: 'flow-1',
+            name: 'Test Flow',
+            frames: [],
+            connections: [
+              {
+                id: 'conn-1',
+                sourceFrameId: 'frame-1',
+                targetContextId: 'ctx-target',
+                eventId: 'evt-nonexistent',
+                connectionType: 'crosses-to',
+                schemaContract: {
+                  eventType: 'SomeEvent',
+                  fields: [{ name: 'id', type: 'string', required: true }],
+                  relationshipType: 'partnership',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = validator.validate(ir);
+      const sp02Diagnostics = result.diagnostics.filter((d) => d.ruleId === 'SP-02');
+      expect(sp02Diagnostics).toHaveLength(1);
+      expect(sp02Diagnostics[0].message).toContain('evt-nonexistent');
+    });
+
+    it('accepts resolved event in crossing', () => {
+      const ir = makeMinimalIR({
+        contexts: [
+          makeMinimalContext({
+            id: 'ctx-target',
+            events: [{ id: 'evt-1', name: 'SomeEvent', fields: [] }],
+          }),
+        ],
+        flows: [
+          {
+            id: 'flow-1',
+            name: 'Test Flow',
+            frames: [],
+            connections: [
+              {
+                id: 'conn-1',
+                sourceFrameId: 'frame-1',
+                targetContextId: 'ctx-target',
+                eventId: 'evt-1',
+                connectionType: 'crosses-to',
+                schemaContract: {
+                  eventType: 'SomeEvent',
+                  fields: [{ name: 'id', type: 'string', required: true }],
+                  relationshipType: 'partnership',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = validator.validate(ir);
+      const sp02Diagnostics = result.diagnostics.filter((d) => d.ruleId === 'SP-02');
+      expect(sp02Diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe('SP-03', () => {
+    it('rejects crossing with empty contract', () => {
+      const ir = makeMinimalIR({
+        contexts: [
+          makeMinimalContext({
+            id: 'ctx-target',
+            events: [{ id: 'evt-1', name: 'SomeEvent', fields: [] }],
+          }),
+        ],
+        flows: [
+          {
+            id: 'flow-1',
+            name: 'Test Flow',
+            frames: [],
+            connections: [
+              {
+                id: 'conn-1',
+                sourceFrameId: 'frame-1',
+                targetContextId: 'ctx-target',
+                eventId: 'evt-1',
+                connectionType: 'crosses-to',
+                schemaContract: {
+                  eventType: 'SomeEvent',
+                  fields: [],
+                  relationshipType: 'partnership',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = validator.validate(ir);
+      const sp03Diagnostics = result.diagnostics.filter((d) => d.ruleId === 'SP-03');
+      expect(sp03Diagnostics).toHaveLength(1);
+      expect(sp03Diagnostics[0].message).toContain('empty schema contract');
+    });
+
+    it('accepts crossing with populated contract', () => {
+      const ir = makeMinimalIR({
+        contexts: [
+          makeMinimalContext({
+            id: 'ctx-target',
+            events: [{ id: 'evt-1', name: 'SomeEvent', fields: [] }],
+          }),
+        ],
+        flows: [
+          {
+            id: 'flow-1',
+            name: 'Test Flow',
+            frames: [],
+            connections: [
+              {
+                id: 'conn-1',
+                sourceFrameId: 'frame-1',
+                targetContextId: 'ctx-target',
+                eventId: 'evt-1',
+                connectionType: 'crosses-to',
+                schemaContract: {
+                  eventType: 'SomeEvent',
+                  fields: [{ name: 'orderId', type: 'string', required: true }],
+                  relationshipType: 'partnership',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = validator.validate(ir);
+      const sp03Diagnostics = result.diagnostics.filter((d) => d.ruleId === 'SP-03');
+      expect(sp03Diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe('SP-04', () => {
+    it('rejects out-of-order frame references', () => {
+      const ir = makeMinimalIR({
+        contexts: [makeMinimalContext({ id: 'ctx-a' }), makeMinimalContext({ id: 'ctx-b' })],
+        flows: [
+          {
+            id: 'flow-1',
+            name: 'Test Flow',
+            frames: [
+              makeFrame({
+                id: 'frame-0',
+                name: 'Frame 0',
+                contextEntries: [{ contextId: 'ctx-a', nodeName: 'Cmd', nodeKind: 'command' }],
+              }),
+              makeFrame({
+                id: 'frame-1',
+                name: 'Frame 1',
+                contextEntries: [{ contextId: 'ctx-b', nodeName: 'Evt', nodeKind: 'event' }],
+              }),
+            ],
+            connections: [
+              {
+                id: 'conn-1',
+                sourceFrameId: 'frame-0',
+                targetContextId: 'ctx-b',
+                eventId: 'evt-1',
+                connectionType: 'returns-to',
+              } as ConnectionDefinition,
+            ],
+          },
+        ],
+      });
+
+      const result = validator.validate(ir);
+      const sp04Diagnostics = result.diagnostics.filter((d) => d.ruleId === 'SP-04');
+      expect(sp04Diagnostics).toHaveLength(1);
+      expect(sp04Diagnostics[0].message).toContain('not prior');
+    });
+
+    it('accepts temporally ordered frames', () => {
+      const ir = makeMinimalIR({
+        contexts: [makeMinimalContext({ id: 'ctx-a' }), makeMinimalContext({ id: 'ctx-b' })],
+        flows: [
+          {
+            id: 'flow-1',
+            name: 'Test Flow',
+            frames: [
+              makeFrame({
+                id: 'frame-0',
+                name: 'Frame 0',
+                contextEntries: [{ contextId: 'ctx-a', nodeName: 'Cmd', nodeKind: 'command' }],
+              }),
+              makeFrame({
+                id: 'frame-1',
+                name: 'Frame 1',
+                contextEntries: [{ contextId: 'ctx-b', nodeName: 'Evt', nodeKind: 'event' }],
+              }),
+            ],
+            connections: [
+              {
+                id: 'conn-1',
+                sourceFrameId: 'frame-1',
+                targetContextId: 'ctx-a',
+                eventId: 'evt-1',
+                connectionType: 'returns-to',
+              } as ConnectionDefinition,
+            ],
+          },
+        ],
+      });
+
+      const result = validator.validate(ir);
+      const sp04Diagnostics = result.diagnostics.filter((d) => d.ruleId === 'SP-04');
+      expect(sp04Diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe('SP-05', () => {
+    it('rejects non-existent manifest file reference', () => {
+      const files = [
+        { name: 'context-a', path: './contexts/a.moment' },
+        { name: 'context-b', path: './contexts/b.moment' },
+      ];
+      const fileExists = (path: string) => path !== './contexts/b.moment';
+
+      const result = validator.validateManifestFiles(files, fileExists);
+      expect(result.valid).toBe(false);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0].ruleId).toBe('SP-05');
+      expect(result.diagnostics[0].message).toContain('./contexts/b.moment');
+    });
+
+    it('accepts valid manifest file references', () => {
+      const files = [
+        { name: 'context-a', path: './contexts/a.moment' },
+        { name: 'context-b', path: './contexts/b.moment' },
+      ];
+      const fileExists = () => true;
+
+      const result = validator.validateManifestFiles(files, fileExists);
+      expect(result.valid).toBe(true);
+      expect(result.diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe('Integration', () => {
+    it('valid spec produces zero diagnostics', () => {
+      const ir = makeMinimalIR({
+        contexts: [
+          makeMinimalContext({
+            id: 'ctx-ordering',
+            events: [
+              {
+                id: 'evt-placed',
+                name: 'OrderPlaced',
+                fields: [{ name: 'orderId', type: 'string', isArray: false, required: true }],
+              },
+            ],
+          }),
+          makeMinimalContext({
+            id: 'ctx-shipping',
+            events: [
+              {
+                id: 'evt-shipped',
+                name: 'OrderShipped',
+                fields: [{ name: 'orderId', type: 'string', isArray: false, required: true }],
+              },
+            ],
+          }),
+        ],
+        flows: [
+          {
+            id: 'flow-order',
+            name: 'Order Flow',
+            frames: [
+              makeFrame({
+                id: 'frame-0',
+                name: 'Place Order',
+                contextEntries: [
+                  { contextId: 'ctx-ordering', nodeName: 'PlaceOrder', nodeKind: 'command' },
+                ],
+              }),
+              makeFrame({
+                id: 'frame-1',
+                name: 'Ship Order',
+                contextEntries: [
+                  { contextId: 'ctx-shipping', nodeName: 'ShipOrder', nodeKind: 'command' },
+                ],
+              }),
+            ],
+            connections: [
+              {
+                id: 'conn-cross',
+                sourceFrameId: 'frame-0',
+                targetContextId: 'ctx-shipping',
+                eventId: 'evt-shipped',
+                connectionType: 'crosses-to',
+                schemaContract: {
+                  eventType: 'OrderShipped',
+                  fields: [{ name: 'orderId', type: 'string', required: true }],
+                  relationshipType: 'partnership',
+                },
+              },
+            ],
+          },
+        ],
+        glossary: [{ term: 'Order', definition: 'A purchase request' }],
+        relationships: [],
+        metadata: { name: 'ecommerce', version: '1.0.0' },
+      });
+
+      const result = validator.validate(ir);
+      expect(result.valid).toBe(true);
+      expect(result.diagnostics).toHaveLength(0);
+    });
+
+    it('returns typed ValidationResult', () => {
+      const ir = makeMinimalIR();
+      const result: ValidationResult = validator.validate(ir);
+      expect(result).toHaveProperty('valid');
+      expect(result).toHaveProperty('diagnostics');
+      expect(typeof result.valid).toBe('boolean');
+      expect(Array.isArray(result.diagnostics)).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,2 @@
 export * from './ir/index.js';
+export * from './services/index.js';

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,0 +1,1 @@
+export { SchemaValidator } from './schema-validator.js';

--- a/packages/core/src/services/schema-validator.ts
+++ b/packages/core/src/services/schema-validator.ts
@@ -1,0 +1,116 @@
+import type { IntermediateRepresentation, ValidationResult, Diagnostic } from '../ir/index.js';
+
+export class SchemaValidator {
+  validate(ir: IntermediateRepresentation): ValidationResult {
+    const diagnostics: Diagnostic[] = [];
+    this.checkSP01(ir, diagnostics);
+    this.checkSP02(ir, diagnostics);
+    this.checkSP03(ir, diagnostics);
+    this.checkSP04(ir, diagnostics);
+    return { valid: diagnostics.length === 0, diagnostics };
+  }
+
+  validateManifestFiles(
+    files: Array<{ name: string; path: string }>,
+    fileExists: (path: string) => boolean,
+  ): ValidationResult {
+    const diagnostics: Diagnostic[] = [];
+    for (const file of files) {
+      if (!fileExists(file.path)) {
+        diagnostics.push({
+          severity: 'error',
+          message: `SP-05: File '${file.path}' referenced in manifest does not exist.`,
+          ruleId: 'SP-05',
+        });
+      }
+    }
+    return { valid: diagnostics.length === 0, diagnostics };
+  }
+
+  private checkSP01(ir: IntermediateRepresentation, diagnostics: Diagnostic[]): void {
+    const contextIds = new Set(ir.contexts.map((c) => c.id));
+    for (const flow of ir.flows) {
+      for (const conn of flow.connections) {
+        if (conn.connectionType === 'crosses-to' && !contextIds.has(conn.targetContextId)) {
+          diagnostics.push({
+            severity: 'error',
+            message: `SP-01: Connection '${conn.id}' references unknown context '${conn.targetContextId}'.`,
+            ruleId: 'SP-01',
+          });
+        }
+      }
+    }
+  }
+
+  private checkSP02(ir: IntermediateRepresentation, diagnostics: Diagnostic[]): void {
+    const contextEventsMap = new Map<string, Set<string>>();
+    for (const ctx of ir.contexts) {
+      const eventIds = new Set(ctx.events.map((e) => e.id));
+      contextEventsMap.set(ctx.id, eventIds);
+    }
+
+    for (const flow of ir.flows) {
+      for (const conn of flow.connections) {
+        if (conn.connectionType === 'crosses-to') {
+          const targetEvents = contextEventsMap.get(conn.targetContextId);
+          if (targetEvents && !targetEvents.has(conn.eventId)) {
+            diagnostics.push({
+              severity: 'error',
+              message: `SP-02: Connection '${conn.id}' references unknown event '${conn.eventId}' in context '${conn.targetContextId}'.`,
+              ruleId: 'SP-02',
+            });
+          }
+        }
+      }
+    }
+  }
+
+  private checkSP03(ir: IntermediateRepresentation, diagnostics: Diagnostic[]): void {
+    for (const flow of ir.flows) {
+      for (const conn of flow.connections) {
+        if (conn.connectionType === 'crosses-to') {
+          if (conn.schemaContract.fields.length === 0) {
+            diagnostics.push({
+              severity: 'error',
+              message: `SP-03: Crossing connection '${conn.id}' has an empty schema contract.`,
+              ruleId: 'SP-03',
+            });
+          }
+        }
+      }
+    }
+  }
+
+  private checkSP04(ir: IntermediateRepresentation, diagnostics: Diagnostic[]): void {
+    for (const flow of ir.flows) {
+      const frameIndexMap = new Map<string, number>();
+      flow.frames.forEach((frame, index) => {
+        frameIndexMap.set(frame.id, index);
+      });
+
+      for (const conn of flow.connections) {
+        if (conn.connectionType === 'returns-to') {
+          const sourceIndex = frameIndexMap.get(conn.sourceFrameId);
+          const targetFrameIds = flow.frames
+            .filter((f) => f.contextEntries.some((e) => e.contextId === conn.targetContextId))
+            .map((f) => f.id);
+
+          for (const targetFrameId of targetFrameIds) {
+            const targetIndex = frameIndexMap.get(targetFrameId);
+            if (
+              sourceIndex !== undefined &&
+              targetIndex !== undefined &&
+              targetIndex >= sourceIndex
+            ) {
+              diagnostics.push({
+                severity: 'error',
+                message: `SP-04: Connection '${conn.id}' returns-to a frame that is not prior (source frame index ${sourceIndex}, target frame index ${targetIndex}).`,
+                ruleId: 'SP-04',
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implement `SchemaValidator` domain service enforcing SP-01 through SP-05
- Pure function — no I/O in `validate()`, SP-05 uses injected `fileExists` callback
- 12 tests matching Xray Test MMNT-822

## Validators

| Rule | Check |
|------|-------|
| SP-01 | Crossing connections reference existing context IDs |
| SP-02 | Crossing events exist in target context |
| SP-03 | Crossings have non-empty schema contracts |
| SP-04 | returns-to connections only reference prior frames |
| SP-05 | Manifest file references exist on disk (injected check) |

## Input Gates
- MMNT-83 (A): Done | MMNT-84 (B): Done — Xray MMNT-822

## Test Plan
- [x] 147 tests pass (12 new + 135 existing)
- [x] Build + lint clean

https://claude.ai/code/session_01C8WYHamocePpeCgj7qXKsH