### PR TITLE
fix(core): address ManifestReader review feedback (MMNT-32)

### DIFF
--- a/packages/core/__tests__/manifest/manifest-reader.spec.ts
+++ b/packages/core/__tests__/manifest/manifest-reader.spec.ts
@@ -111,6 +111,62 @@ name: TestProject
 
       expect(() => reader.readManifest(manifestPath)).toThrow();
     });
+
+    it('throws when root is not an object', () => {
+      const manifestPath = writeManifest('just a string');
+      expect(() => reader.readManifest(manifestPath)).toThrow('expected a YAML object');
+    });
+
+    it('throws when contexts is not an array', () => {
+      const manifestPath = writeManifest(`
+name: Test
+contexts: not-an-array
+`);
+      expect(() => reader.readManifest(manifestPath)).toThrow('file references must be an array');
+    });
+
+    it('throws when generators has invalid format', () => {
+      const manifestPath = writeManifest(`
+name: Test
+generators:
+  - format: invalid
+    outputDir: ./out
+`);
+      expect(() => reader.readManifest(manifestPath)).toThrow('invalid generator format');
+    });
+
+    it('throws when generator entry is null', () => {
+      const manifestPath = writeManifest(`
+name: Test
+generators:
+  - null
+`);
+      expect(() => reader.readManifest(manifestPath)).toThrow('not a valid object');
+    });
+
+    it('coerces non-string name and version to defaults', () => {
+      const manifestPath = writeManifest(`
+name: 123
+version: true
+`);
+      const config = reader.readManifest(manifestPath);
+      expect(config.name).toBe('');
+      expect(config.version).toBe('0.0.0');
+    });
+
+    it('handles watch config with invalid types gracefully', () => {
+      const manifestPath = writeManifest(`
+name: Test
+watch:
+  enabled: "yes"
+  debounceMs: "fast"
+  paths: not-an-array
+`);
+      const config = reader.readManifest(manifestPath);
+      expect(config.watch.enabled).toBe(false);
+      expect(config.watch.debounceMs).toBe(300);
+      expect(config.watch.paths).toEqual([]);
+    });
   });
 
   describe('SP-05', () => {

--- a/packages/core/src/manifest/manifest-reader.ts
+++ b/packages/core/src/manifest/manifest-reader.ts
@@ -24,6 +24,10 @@ export class ManifestReader {
     }
 
     const obj = raw as Record<string, unknown>;
+    const name = typeof obj.name === 'string' ? obj.name : '';
+    const version = typeof obj.version === 'string' ? obj.version : '0.0.0';
+    const description = typeof obj.description === 'string' ? obj.description : undefined;
+
     const contexts = this.parseFileRefs(obj.contexts);
     const flows = this.parseFileRefs(obj.flows);
     const generators = this.parseGenerators(obj.generators);
@@ -31,15 +35,7 @@ export class ManifestReader {
 
     this.validateFileRefs(manifestDir, contexts, flows);
 
-    return {
-      name: (obj.name as string) ?? '',
-      version: (obj.version as string) ?? '0.0.0',
-      description: obj.description as string | undefined,
-      contexts,
-      flows,
-      generators,
-      watch,
-    };
+    return { name, version, description, contexts, flows, generators, watch };
   }
 
   private parseFileRefs(entries: unknown): FileRef[] {
@@ -50,7 +46,7 @@ export class ManifestReader {
       throw new Error('Manifest validation failed: file references must be an array.');
     }
     return entries.map((e, index) => {
-      if (e == null || typeof e !== 'object') {
+      if (e == null || typeof e !== 'object' || Array.isArray(e)) {
         throw new Error(
           `Manifest validation failed: file reference at index ${index} is not an object.`,
         );
@@ -73,29 +69,43 @@ export class ManifestReader {
       throw new Error('Manifest validation failed: generators must be an array.');
     }
     return entries.map((g, index) => {
-      const candidate = g as { format?: string; outputDir?: string };
-      if (!candidate.format || !ALLOWED_FORMATS.has(candidate.format as 'typescript')) {
+      if (g == null || typeof g !== 'object' || Array.isArray(g)) {
+        throw new Error(
+          `Manifest validation failed: generator at index ${index} is not a valid object.`,
+        );
+      }
+      const candidate = g as { format?: unknown; outputDir?: unknown };
+      if (
+        typeof candidate.format !== 'string' ||
+        !ALLOWED_FORMATS.has(candidate.format as 'typescript')
+      ) {
         throw new Error(
           `Manifest validation failed: invalid generator format '${candidate.format}' at index ${index}. Supported: ${[...ALLOWED_FORMATS].join(', ')}.`,
         );
       }
+      if (candidate.outputDir !== undefined && typeof candidate.outputDir !== 'string') {
+        throw new Error(
+          `Manifest validation failed: 'outputDir' for generator at index ${index} must be a string.`,
+        );
+      }
       return {
         format: candidate.format as 'typescript' | 'gherkin' | 'markdown',
-        outputDir: candidate.outputDir ?? '',
+        outputDir: typeof candidate.outputDir === 'string' ? candidate.outputDir : '',
       };
     });
   }
 
   private parseWatch(raw: unknown): WatchConfiguration {
-    if (raw == null || typeof raw !== 'object') {
+    if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) {
       return { enabled: false, debounceMs: 300, paths: [] };
     }
-    const obj = raw as { enabled?: boolean; debounceMs?: number; paths?: string[] };
-    return {
-      enabled: obj.enabled ?? false,
-      debounceMs: obj.debounceMs ?? 300,
-      paths: obj.paths ?? [],
-    };
+    const obj = raw as Record<string, unknown>;
+    const enabled = typeof obj.enabled === 'boolean' ? obj.enabled : false;
+    const debounceMs = typeof obj.debounceMs === 'number' ? obj.debounceMs : 300;
+    const paths = Array.isArray(obj.paths)
+      ? obj.paths.filter((p): p is string => typeof p === 'string')
+      : [];
+    return { enabled, debounceMs, paths };
   }
 
   private validateFileRefs(manifestDir: string, contexts: FileRef[], flows: FileRef[]): void {


### PR DESCRIPTION
## Summary

Follow-up fixes for Copilot review feedback on PR #18 (MMNT-32 ManifestReader):

- Add runtime shape check for `parseYaml()` result (reject non-objects)
- Add `Array.isArray()` guard + per-entry type validation in `parseFileRefs`
- Add explicit format allowlist validation in `parseGenerators`
- Use `dirname()` instead of string split in test helper

https://claude.ai/code/session_01C8WYHamocePpeCgj7qXKsH