### PR TITLE
test(core): integration tests — parse sample files to IR, M2 gate (MMNT-37)

### DIFF
--- a/packages/core/__tests__/integration/parse-pipeline.integration.spec.ts
+++ b/packages/core/__tests__/integration/parse-pipeline.integration.spec.ts
@@ -71,9 +71,12 @@ describe('Parse Pipeline Integration', () => {
     it('IR serializes to JSON and deserializes losslessly', async () => {
       const content = readFixture('valid/minimal/contexts/ordering.moment');
       const result = await parser.parseContent(content);
-      const json = JSON.stringify(result.ir);
+      expect(result.success).toBe(true);
+      expect(result.ir).toBeDefined();
+      const ir = result.ir!;
+      const json = JSON.stringify(ir);
       const deserialized = JSON.parse(json);
-      expect(deserialized).toEqual(result.ir);
+      expect(deserialized).toEqual(ir);
     });
   });
 
@@ -93,11 +96,18 @@ describe('Parse Pipeline Integration', () => {
     });
 
     it('valid input with warnings still produces IR', async () => {
-      // A valid flow that parses successfully — warnings don't block IR
-      const content = readFixture('valid/minimal/contexts/ordering.moment');
+      // Flow with an unused branch-lane triggers V16 warning but still parses
+      const content = `
+        flow "test-warnings"
+          lane a "A" [Core]
+          branch-lane unused "Unused" [Terminal]
+          frame "Step"
+            a: SomeEvent
+      `;
       const result = await parser.parseContent(content);
       expect(result.success).toBe(true);
       expect(result.ir).toBeDefined();
+      expect(result.diagnostics.some((d) => d.severity === 'warning')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

M2 partial gate — end-to-end integration tests verifying the complete parse pipeline:
`.moment` files → MomentParser → IntermediateRepresentation

- 8 integration tests using the public `MomentParser` API only
- Tests both minimal (2-context) and multi-context (3-context + branching) sample files
- JSON round-trip serialization test proves IR is losslessly serializable
- Error scenario tests verify diagnostics for malformed input

## Input Gates
- MMNT-100 (A): Done | MMNT-101 (B): Done — Xray MMNT-901

## Test Plan
- [x] 201 tests pass (8 new integration + 193 existing)
- [x] Build + lint clean
- [x] Uses public API only — no internal imports (EXIT-C1)
- [x] Uses canonical fixture files from Sample Files page (EXIT-C2)

https://claude.ai/code/session_01C8WYHamocePpeCgj7qXKsH