### PR TITLE
ci: add test-traceability-verification gate (ADR-016 §9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,30 +201,47 @@ jobs:
 
           echo "Checking test traceability for $STORY_KEY..."
 
-          # Check for Traceability Verification subtask (D)
-          RESPONSE=$(curl -s -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+          # Fetch story with subtasks and issue links
+          HTTP_CODE=$(curl -s -o /tmp/jira_response.json -w "%{http_code}" -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
             "https://winnovation.atlassian.net/rest/api/3/issue/$STORY_KEY?fields=subtasks,issuelinks")
 
-          GATE_D_STATUS=$(echo "$RESPONSE" | jq -r \
-            '.fields.subtasks[] | select(.fields.summary | test("-D — Traceability Verification")) | .fields.status.name')
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Traceability gate failed: Jira API returned HTTP $HTTP_CODE for $STORY_KEY. Response: $(cat /tmp/jira_response.json | head -c 200)"
+            exit 1
+          fi
 
-          if [ -z "$GATE_D_STATUS" ]; then
+          RESPONSE=$(cat /tmp/jira_response.json)
+
+          # Validate response has expected fields
+          if echo "$RESPONSE" | jq -e '.errorMessages' > /dev/null 2>&1; then
+            echo "::error::Traceability gate failed: Jira API error for $STORY_KEY: $(echo "$RESPONSE" | jq -r '.errorMessages[]')"
+            exit 1
+          fi
+
+          # Check for Traceability Verification subtask (D) — expect exactly one match
+          GATE_D_COUNT=$(echo "$RESPONSE" | jq '[.fields.subtasks[] | select(.fields.summary | test("-D — Traceability Verification"))] | length')
+          GATE_D_STATUS=$(echo "$RESPONSE" | jq -r '[.fields.subtasks[] | select(.fields.summary | test("-D — Traceability Verification"))][0].fields.status.name // empty')
+
+          if [ "$GATE_D_COUNT" -eq 0 ]; then
             echo "::error::Traceability gate failed: No Traceability Verification subtask found for $STORY_KEY."
+            exit 1
+          elif [ "$GATE_D_COUNT" -gt 1 ]; then
+            echo "::error::Traceability gate failed: Multiple Traceability Verification subtasks found for $STORY_KEY ($GATE_D_COUNT matches). Expected exactly one."
             exit 1
           elif [ "$GATE_D_STATUS" != "Done" ]; then
             echo "::error::Traceability gate failed: Traceability Verification subtask for $STORY_KEY is '$GATE_D_STATUS', expected 'Done'."
             exit 1
           fi
 
-          # Verify the story has at least one 'tests' issue link
+          # Verify the story has at least one 'Test' issue link
           TEST_LINK_COUNT=$(echo "$RESPONSE" | jq '[.fields.issuelinks[] | select(.type.name == "Test")] | length')
 
           if [ "$TEST_LINK_COUNT" -eq 0 ]; then
-            echo "::error::Traceability gate failed: $STORY_KEY has zero 'tests' issue links. All Test issues must be linked to the parent story."
+            echo "::error::Traceability gate failed: $STORY_KEY has zero 'Test' issue links. All Test issues must be linked to the parent story."
             exit 1
           fi
 
-          echo "✅ Test traceability verified: Subtask D (Done), $TEST_LINK_COUNT test links found."
+          echo "✅ Test traceability verified: Subtask D (Done), $TEST_LINK_COUNT Test issue link(s) found."
         env:
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
## Summary

Add structural enforcement for test traceability — the agent can no longer skip linking Test issues to parent stories because CI blocks the merge.

### Changes

**CI Workflow** (`.github/workflows/ci.yml`):
- New `test-traceability-verification` job that runs on every PR
- Checks that Subtask D (`-D — Traceability Verification`) is Done
- Checks that the parent story has at least one `tests` issue link
- Follows the same pattern as `input-gate-verification` (§5)

**ADR-016** (Confluence page 14548994, updated to v5):
- New **Subtask D — Traceability Verification**: Mandatory subtask that verifies all Test issues are linked before merge
- New **§9 — Test Traceability Enforcement**: CI gate specification with workflow YAML, failure modes, and relationship to §5
- Updated §6 naming convention: `{story-key}-D — Traceability Verification`
- Updated dependency chain: A → B → C → D

### Why this exists

During Sprint 2, the agent repeatedly skipped test traceability linking when:
1. Jira MCP tools were unavailable (rationalized as "will fix later")
2. Jira API returned transient errors (rationalized as "API is flaky")
3. Velocity pressure led to skipping non-blocking steps

Instruction-based requirements (v2-v4 amendments) were insufficient because the agent could rationalize skipping them. Structural enforcement via CI gate removes the agent's ability to skip — the PR physically cannot merge without the gate passing.

### Defense in Depth

| Gate | What It Checks | Lifecycle Stage |
|------|---------------|-----------------|
| `input-gate-verification` (§5) | A + B subtasks Done | Before implementation |
| `test-traceability-verification` (§9) | D subtask Done + test links exist | After implementation |

https://claude.ai/code/session_01C8WYHamocePpeCgj7qXKsH