### PR TITLE
ci: auto-transition Test issues to Done on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,32 +351,50 @@ jobs:
         run: |
           echo "Scanning for non-Done Test and Test Execution issues with Done parent stories..."
 
-          # Find all Test/Test Execution issues that are NOT Done and have a 'tests' link to a Done story
-          ISSUES=$(curl -s -G "https://winnovation.atlassian.net/rest/api/3/search/jql" \
-            --data-urlencode "jql=project=MMNT AND issuetype in (Test, 'Test Execution') AND status != Done ORDER BY key ASC" \
-            --data-urlencode "maxResults=100" \
-            --data-urlencode "fields=key,issuelinks" \
-            -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN")
-
-          # For each issue, check if its linked parent story is Done, then transition
           TRANSITIONED=0
-          echo "$ISSUES" | jq -r '.issues[]? | .key' | while read -r KEY; do
-            # Get the linked story status
-            PARENT_DONE=$(echo "$ISSUES" | jq -r --arg key "$KEY" '
-              .issues[] | select(.key == $key) |
-              .fields.issuelinks[]? |
-              select(.type.name == "Test" and .outwardIssue != null) |
-              select(.outwardIssue.fields.status.name == "Done") |
-              .outwardIssue.key' | head -1)
+          START_AT=0
+          PAGE_SIZE=100
 
-            if [ -n "$PARENT_DONE" ]; then
-              curl -s -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
-                -X POST "https://winnovation.atlassian.net/rest/api/3/issue/$KEY/transitions" \
-                -H "Content-Type: application/json" \
-                -d '{"transition":{"id":"31"}}' > /dev/null 2>&1
-              TRANSITIONED=$((TRANSITIONED + 1))
-              echo "  $KEY → Done (parent: $PARENT_DONE)"
+          while true; do
+            RESPONSE=$(curl -s -G "https://winnovation.atlassian.net/rest/api/3/search/jql" \
+              --data-urlencode "jql=project=MMNT AND issuetype in (Test, 'Test Execution') AND status != Done ORDER BY key ASC" \
+              --data-urlencode "maxResults=$PAGE_SIZE" \
+              --data-urlencode "startAt=$START_AT" \
+              --data-urlencode "fields=key,issuelinks" \
+              -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN")
+
+            COUNT=$(echo "$RESPONSE" | jq '.issues | length')
+            if [ "$COUNT" -eq 0 ]; then
+              break
             fi
+
+            # Extract keys into array to avoid subshell counter issue
+            KEYS=$(echo "$RESPONSE" | jq -r '.issues[]? | .key')
+
+            for KEY in $KEYS; do
+              PARENT_DONE=$(echo "$RESPONSE" | jq -r --arg key "$KEY" '
+                first(
+                  .issues[] | select(.key == $key) |
+                  .fields.issuelinks[]? |
+                  select(.type.name == "Test" and .outwardIssue != null) |
+                  select(.outwardIssue.fields.status.name == "Done") |
+                  .outwardIssue.key
+                ) // empty')
+
+              if [ -n "$PARENT_DONE" ]; then
+                if curl --fail -s -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+                  -X POST "https://winnovation.atlassian.net/rest/api/3/issue/$KEY/transitions" \
+                  -H "Content-Type: application/json" \
+                  -d '{"transition":{"id":"31"}}' > /dev/null 2>&1; then
+                  TRANSITIONED=$((TRANSITIONED + 1))
+                  echo "  $KEY → Done (parent: $PARENT_DONE)"
+                else
+                  echo "  Failed to transition $KEY (parent: $PARENT_DONE)" >&2
+                fi
+              fi
+            done
+
+            START_AT=$((START_AT + PAGE_SIZE))
           done
 
           echo "Transitioned $TRANSITIONED Test issues to Done."


### PR DESCRIPTION
## Summary

New CI job `close-test-issues` that **automatically transitions linked Test and Test Execution issues to Done** when a PR merges to main.

### Problem
Sprint 2 had 320+ Test issues stuck in `Planned` while their parent stories were `Done`. This required manual cleanup twice during the sprint. The root cause: nothing automatically closes Test issues when the story they validate is completed.

### Solution
A post-merge CI job that:
1. Runs **only on push to main** (after PR merge), not on PRs
2. Queries Jira for non-Done Test/Test Execution issues
3. Checks each one's `tests` link — if the linked parent story is Done, transitions the Test issue to Done
4. Runs after `build` to ensure it only fires on successful merges

### How it fits the enforcement model

| Gate | When | What |
|------|------|------|
| `input-gate-verification` (§5) | PR time | A + B subtasks must be Done |
| `test-traceability-verification` (§9) | PR time | D subtask must be Done + test links exist |
| `close-test-issues` (new) | **Post-merge** | Auto-transition linked Test issues to Done |

The first two are blocking gates. This third one is a cleanup automation — it doesn't block anything, it just ensures the backlog stays clean.

https://claude.ai/code/session_01C8WYHamocePpeCgj7qXKsH