### PR TITLE
Enhance deriveTopology with optional derivedAt and safer context resolution

### DIFF
--- a/packages/derive/src/engine/__tests__/derivation-engine.spec.ts
+++ b/packages/derive/src/engine/__tests__/derivation-engine.spec.ts
@@ -510,5 +510,48 @@ describe('DerivationEngine', () => {
       expect(assertion.sourceContext).toBe('ctx-1');
       expect(assertion.targetContext).toBe('ctx-2');
     });
+
+    it('frame with empty contextEntries but branch entries resolves source from branches', () => {
+      const ctx1 = makeContext('ctx-1', 'Ordering', [
+        makeEvent('OrderPlaced-event', 'OrderPlaced'),
+      ]);
+      const ctx2 = makeContext('ctx-2', 'Shipping', [
+        makeEvent('OrderPlaced-event', 'OrderPlaced'),
+      ]);
+      const frame: FrameDefinition = {
+        id: 'fr1',
+        name: 'Branch-Only Frame',
+        contextEntries: [],
+        branches: [
+          {
+            condition: 'always',
+            entries: [{ contextId: 'ctx-1', nodeName: 'PlaceOrder', nodeKind: 'command' }],
+          },
+        ],
+      };
+      const conn = makeCrossingConnection('c1', 'fr1', 'ctx-2', 'OrderPlaced');
+      const flow = makeFlow('f1', 'Branch Entry Flow', [frame], [conn]);
+      const ir = makeIR({ contexts: [ctx1, ctx2], flows: [flow] });
+
+      const topology = deriveTopology(ir);
+
+      const assertion = topology.suites[0].testCases[0].assertions[0];
+      expect(assertion.sourceContext).toBe('ctx-1');
+    });
+
+    it('single-context frame returns that context as source', () => {
+      const ctx1 = makeContext('ctx-1', 'Ordering');
+      const ctx2 = makeContext('ctx-2', 'Fulfillment', [
+        makeEvent('OrderPlaced-event', 'OrderPlaced'),
+      ]);
+      const frame = makeFrame('fr1', 'Single Context', 'ctx-1', 'PlaceOrder');
+      const conn = makeCrossingConnection('c1', 'fr1', 'ctx-2', 'OrderPlaced');
+      const flow = makeFlow('f1', 'Single Ctx Flow', [frame], [conn]);
+      const ir = makeIR({ contexts: [ctx1, ctx2], flows: [flow] });
+
+      const topology = deriveTopology(ir);
+
+      expect(topology.suites[0].testCases[0].assertions[0].sourceContext).toBe('ctx-1');
+    });
   });
 });

--- a/packages/derive/src/engine/derivation-engine.ts
+++ b/packages/derive/src/engine/derivation-engine.ts
@@ -78,9 +78,25 @@ function resolveSourceContextId(
   const branchEntries = (frame.branches ?? []).flatMap((b) => b.entries);
   const allEntries = [...frame.contextEntries, ...branchEntries];
 
-  // For multi-context frames, prefer the entry that is NOT the crossing target
-  const nonTarget = allEntries.find((e) => e.contextId !== conn.targetContextId);
-  return nonTarget ? nonTarget.contextId : allEntries[0].contextId;
+  // Single context — unambiguous
+  if (allEntries.length === 1) {
+    return allEntries[0].contextId;
+  }
+
+  // Multi-context: filter out the target to find source candidates
+  const nonTargetEntries = allEntries.filter((e) => e.contextId !== conn.targetContextId);
+
+  if (nonTargetEntries.length === 1) {
+    return nonTargetEntries[0].contextId;
+  }
+
+  // All entries are the target context — return it
+  if (nonTargetEntries.length === 0) {
+    return allEntries[0].contextId;
+  }
+
+  // Ambiguous: multiple distinct non-target contexts — use first
+  return nonTargetEntries[0].contextId;
 }
 
 function mapCrossingToAssertion(


### PR DESCRIPTION
This pull request updates the `deriveTopology` and crossing assertion logic in the derivation engine to improve determinism and correctness, especially in handling context resolution for "crosses-to" connections.

**Improvements to determinism and metadata:**

* The `deriveTopology` function now accepts an optional `derivedAt` timestamp. If not provided, it defaults to the current time, making the function pure when a timestamp is supplied.

**Enhancements to context resolution for crossings:**

* Introduced the `resolveSourceContextId` helper to robustly determine the source context for "crosses-to" connections in frames, handling both single- and multi-context scenarios and throwing an error if no context entries are present.
* Updated `mapCrossingToAssertion` to use `resolveSourceContextId`, improving correctness in selecting the source context for assertion points.…e context resolution

1. deriveTopology now accepts optional derivedAt parameter for deterministic output. Falls back to current time if omitted.
2. resolveSourceContextId replaces bare frame.contextEntries[0] access — handles empty frames and multi-context frames by excluding the target context.

https://claude.ai/code/session_01C8WYHamocePpeCgj7qXKsH