### PR TITLE
test(harness): integration test — harness API validation [MMNT-109]

### DIFF
--- a/packages/harness/src/__tests__/integration/harness-api.integration.test.ts
+++ b/packages/harness/src/__tests__/integration/harness-api.integration.test.ts
@@ -121,7 +121,7 @@ const sampleTopology: TestSuiteTopology = {
     {
       flowId: 'flow-order-to-ship',
       flowName: 'Order to Ship',
-      contextsCovered: ['Ordering', 'Shipping'],
+      contextsCovered: ['ctx-ordering', 'ctx-shipping'],
       testCases: [
         {
           frameId: 'frame-place',
@@ -216,8 +216,9 @@ describe('Harness API Integration', () => {
 
     expect(result.valid).toBe(false);
     expect(result.violations.length).toBeGreaterThanOrEqual(1);
-    expect(result.violations[0].fieldName).toBe('amount');
-    expect(result.violations[0].constraintViolated).toBe('required field missing');
+    const amountViolation = result.violations.find((v) => v.fieldName === 'amount');
+    expect(amountViolation).toBeDefined();
+    expect(amountViolation!.constraintViolated).toBe('required field missing');
   });
 
   it('EventReplayEngine detects divergence (TE-02)', () => {


### PR DESCRIPTION
## Summary

- 6 integration tests exercising the full `@mmmnt/harness` public API surface as a consumer would
- Tests wire against realistic multi-context IR (Ordering → Shipping) with flows, connections, and schema contracts
- TE-01 (traceability) and TE-02 (divergence detection) each have explicit integration coverage
- Closes Epic 4.1 gate for `@mmmnt/harness`

## Test Scenarios

1. TestRunner produces TestRunResult with traceabilityMap (TE-01)
2. EventReplayEngine replays cross-context event chain
3. ContractAssertionEngine validates valid contract
4. ContractAssertionEngine detects missing required field
5. EventReplayEngine detects divergence (TE-02)
6. Consumer ergonomics — single barrel import, full API accessible

## Coverage

- 26 total tests (20 unit + 6 integration), all passing
- 99% statements, 96% branches

## Test plan

- [x] `pnpm turbo build` exits 0
- [x] `pnpm turbo test --filter @mmmnt/harness` exits 0
- [x] Coverage ≥85%
- [x] EXIT-C1: public API imports only
- [x] EXIT-C2: TE-01 and TE-02 explicitly covered

https://claude.ai/code/session_01C8WYHamocePpeCgj7qXKsH