### PR TITLE
feat(sync): implement ImplementationFeedbackJournal aggregate [MMNT-234]

### DIFF
--- a/packages/sync/src/__tests__/aggregates/implementation-feedback-journal.test.ts
+++ b/packages/sync/src/__tests__/aggregates/implementation-feedback-journal.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { SyncState } from '../../aggregates/sync-state.js';
 import { ImplementationFeedbackJournal } from '../../aggregates/implementation-feedback-journal.js';
-import type {
-  RecordImplementationFeedbackInput,
-  ImplementationFeedbackRecorded,
-} from '../../aggregates/implementation-feedback-journal.js';
+import type { RecordImplementationFeedbackInput } from '../../aggregates/implementation-feedback-journal.js';
 import type { ImplementationChangeProposal, FeedbackEventType } from '../../value-objects/index.js';
 
 function makeProposal(id = 'prop-001'): ImplementationChangeProposal {

--- a/packages/sync/src/aggregates/implementation-feedback-journal.jsonl-schema.ts
+++ b/packages/sync/src/aggregates/implementation-feedback-journal.jsonl-schema.ts
@@ -1,0 +1,11 @@
+import type { ImplementationFeedbackRecorded } from './implementation-feedback-journal.js';
+
+export interface ImplementationFeedbackRecord {
+  readonly event: ImplementationFeedbackRecorded;
+  /**
+   * Time at which this record was appended to the underlying log/store.
+   * Distinct from `event.metadata.timestamp`, which represents the domain event time.
+   */
+  readonly appendedAt: string;
+  readonly version: number;
+}

--- a/packages/sync/src/aggregates/implementation-feedback-journal.ts
+++ b/packages/sync/src/aggregates/implementation-feedback-journal.ts
@@ -11,19 +11,11 @@ import type {
   EventMetadata,
   SourceAttribution,
 } from '../value-objects/index.js';
+import { FEEDBACK_EVENT_TYPES } from '../value-objects/feedback-event-type.js';
 import { SyncState } from './sync-state.js';
 
 // The 8 known feedback event types
-const KNOWN_FEEDBACK_TYPES: ReadonlySet<FeedbackEventType> = new Set([
-  'ValueObjectDefined',
-  'ValueObjectRemoved',
-  'ValueObjectRenamed',
-  'ValueObjectFieldAdded',
-  'ValueObjectFieldRemoved',
-  'ValueObjectFieldRevised',
-  'CommandInputRevised',
-  'DomainEventPayloadRevised',
-]);
+const KNOWN_FEEDBACK_TYPES: ReadonlySet<string> = new Set(FEEDBACK_EVENT_TYPES);
 
 export interface RecordImplementationFeedbackInput {
   readonly feedbackEventType: FeedbackEventType;

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -1,3 +1,4 @@
+export { FEEDBACK_EVENT_TYPES } from './value-objects/index.js';
 export type {
   DifferenceType,
   DriftDirection,
@@ -34,6 +35,7 @@ export type {
 } from './events/sync-state-events.js';
 
 export type { SyncStateRecord } from './aggregates/sync-state.jsonl-schema.js';
+export type { ImplementationFeedbackRecord } from './aggregates/implementation-feedback-journal.jsonl-schema.js';
 
 export { ASTDiffEngine } from './services/ast-diff-engine.js';
 export type {

--- a/packages/sync/src/value-objects/feedback-event-type.ts
+++ b/packages/sync/src/value-objects/feedback-event-type.ts
@@ -1,9 +1,12 @@
-export type FeedbackEventType =
-  | 'ValueObjectDefined'
-  | 'ValueObjectRemoved'
-  | 'ValueObjectRenamed'
-  | 'ValueObjectFieldAdded'
-  | 'ValueObjectFieldRemoved'
-  | 'ValueObjectFieldRevised'
-  | 'CommandInputRevised'
-  | 'DomainEventPayloadRevised';
+export const FEEDBACK_EVENT_TYPES = [
+  'ValueObjectDefined',
+  'ValueObjectRemoved',
+  'ValueObjectRenamed',
+  'ValueObjectFieldAdded',
+  'ValueObjectFieldRemoved',
+  'ValueObjectFieldRevised',
+  'CommandInputRevised',
+  'DomainEventPayloadRevised',
+] as const;
+
+export type FeedbackEventType = (typeof FEEDBACK_EVENT_TYPES)[number];

--- a/packages/sync/src/value-objects/index.ts
+++ b/packages/sync/src/value-objects/index.ts
@@ -1,6 +1,7 @@
 export type { DifferenceType } from './difference-type.js';
 export type { DriftDirection } from './drift-direction.js';
 export type { ProposalStatus } from './proposal-status.js';
+export { FEEDBACK_EVENT_TYPES } from './feedback-event-type.js';
 export type { FeedbackEventType } from './feedback-event-type.js';
 export type { ASTDifference } from './ast-difference.js';
 export type { TypeLevelChange } from './type-level-change.js';


### PR DESCRIPTION
## Summary

ImplementationFeedbackJournal aggregate — append-only journal for confirmed implementation feedback events (`.domain/implementation-feedback.jsonl`):

- **Command**: `RecordImplementationFeedback` with 4 invariants
- **IFJ-01**: Source must be `mmmnt:implementation-feedback`
- **IFJ-02**: Causation chain must reference accepted proposal in SyncState
- **IFJ-03**: Feedback event type must be one of 8 known types
- **IFJ-04**: Actor must be valid non-empty identity
- **EventMetadata** envelope with full provenance (eventId, timestamp, actor, source, causation, correlation, version, commitRef)

## Coverage

- 12 new tests, 90 total across @mmmnt/sync
- All passing

## Test plan

- [x] `pnpm turbo build --filter @mmmnt/sync` exits 0
- [x] `pnpm turbo lint --filter @mmmnt/sync` exits 0
- [x] IFJ-01 through IFJ-04 all tested
- [x] All 8 feedback event types exercised
- [x] Append-only behavior verified
- [x] No `any` types

https://claude.ai/code/session_01C8WYHamocePpeCgj7qXKsH