### PR TITLE
feat(cli): implement moment parse command (MMNT-247)

### DIFF
--- a/packages/cli/src/commands/parse.test.ts
+++ b/packages/cli/src/commands/parse.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { resolve } from 'node:path';
+import { resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { runParse, formatDiagnostic } from './parse.js';
 import type { Diagnostic } from '@mmmnt/core';
 
@@ -8,7 +9,7 @@ const VALID_FIXTURE = resolve(FIXTURES, 'valid/minimal/contexts/ordering.moment'
 const INVALID_FIXTURE = resolve(FIXTURES, 'invalid/no-declaration.moment');
 
 describe('moment parse', () => {
-  it('valid .moment + .manifest.yaml exits 0 with IR summary', async () => {
+  it('valid .moment file returns success with IR summary', async () => {
     const result = await runParse([VALID_FIXTURE]);
 
     expect(result.success).toBe(true);
@@ -16,7 +17,7 @@ describe('moment parse', () => {
     expect(result.contextCount).toBeGreaterThanOrEqual(0);
   });
 
-  it('invalid .moment file exits non-zero with diagnostics', async () => {
+  it('invalid .moment file returns failure with diagnostics', async () => {
     const result = await runParse([INVALID_FIXTURE]);
 
     expect(result.success).toBe(false);
@@ -24,15 +25,16 @@ describe('moment parse', () => {
     expect(result.message).toContain('diagnostic');
   });
 
-  it('no arguments exits non-zero with usage message', async () => {
+  it('no arguments returns failure with usage message', async () => {
     const result = await runParse([]);
 
     expect(result.success).toBe(false);
     expect(result.message).toContain('Usage:');
   });
 
-  it('nonexistent path exits non-zero with file-not-found', async () => {
-    const result = await runParse(['/tmp/nonexistent-file-12345.moment']);
+  it('nonexistent path returns failure with file-not-found', async () => {
+    const nonexistent = join(tmpdir(), 'nonexistent-moment-file-12345.moment');
+    const result = await runParse([nonexistent]);
 
     expect(result.success).toBe(false);
     expect(result.message).toContain('File not found');
@@ -41,8 +43,6 @@ describe('moment parse', () => {
   it('delegates to MomentParser (no grammar/AST logic in CLI)', async () => {
     const result = await runParse([VALID_FIXTURE]);
 
-    // The CLI delegates to MomentParser — it returns ParseResult with IR
-    // No grammar manipulation happens in the CLI layer
     expect(result.success).toBe(true);
     expect(result.contextCount).toBeDefined();
     expect(result.flowCount).toBeDefined();
@@ -60,5 +60,16 @@ describe('moment parse', () => {
     expect(formatted).toContain('test.moment:5:10');
     expect(formatted).toContain('error');
     expect(formatted).toContain('Unexpected token');
+  });
+
+  it('formatDiagnostic uses fallback file when source is missing', () => {
+    const diagnostic: Diagnostic = {
+      severity: 'warning',
+      message: 'Missing declaration',
+    };
+
+    const formatted = formatDiagnostic(diagnostic, 'fallback.moment');
+    expect(formatted).toContain('fallback.moment');
+    expect(formatted).toContain('warning');
   });
 });

--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -8,7 +8,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { MomentParser } from '@mmmnt/core';
-import type { Diagnostic } from '@mmmnt/core';
+import type { Diagnostic, ParseResult } from '@mmmnt/core';
 
 export interface ParseCommandResult {
   readonly success: boolean;
@@ -18,52 +18,60 @@ export interface ParseCommandResult {
   readonly flowCount?: number;
 }
 
-export function formatDiagnostic(d: Diagnostic): string {
-  const loc = d.source ? `${d.source.file}:${d.source.line}:${d.source.column}` : '<unknown>';
+const EMPTY: readonly Diagnostic[] = [];
+
+function fail(message: string): ParseCommandResult {
+  return { success: false, message, diagnostics: EMPTY };
+}
+
+export function formatDiagnostic(d: Diagnostic, fallbackFile?: string): string {
+  const loc = d.source
+    ? `${d.source.file}:${d.source.line}:${d.source.column}`
+    : (fallbackFile ?? '<unknown>');
   return `${d.severity}: ${loc} — ${d.message}`;
 }
 
-export async function runParse(argv: string[]): Promise<ParseCommandResult> {
-  const filePath = argv[0];
+function readFile(path: string): string | ParseCommandResult {
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return fail(`Error: Failed to read ${path}: ${msg}`);
+  }
+}
 
-  if (!filePath) {
+function toResult(parseResult: ParseResult): ParseCommandResult {
+  if (!parseResult.success) {
     return {
       success: false,
-      message: 'Usage: moment parse <file.moment>',
-      diagnostics: [],
+      message: `Parse failed with ${parseResult.diagnostics.length} diagnostic(s)`,
+      diagnostics: parseResult.diagnostics,
     };
   }
 
-  const resolvedPath = resolve(filePath);
-
-  if (!existsSync(resolvedPath)) {
-    return {
-      success: false,
-      message: `Error: File not found: ${resolvedPath}`,
-      diagnostics: [],
-    };
-  }
-
-  const content = readFileSync(resolvedPath, 'utf-8');
-  const parser = new MomentParser();
-  const result = await parser.parseContent(content);
-
-  if (!result.success) {
-    return {
-      success: false,
-      message: `Parse failed with ${result.diagnostics.length} diagnostic(s)`,
-      diagnostics: result.diagnostics,
-    };
-  }
-
-  const contextCount = result.ir?.contexts?.length ?? 0;
-  const flowCount = result.ir?.flows?.length ?? 0;
+  const contextCount = parseResult.ir?.contexts?.length ?? 0;
+  const flowCount = parseResult.ir?.flows?.length ?? 0;
 
   return {
     success: true,
     message: `Parsed successfully: ${contextCount} context(s), ${flowCount} flow(s)`,
-    diagnostics: result.diagnostics,
+    diagnostics: parseResult.diagnostics,
     contextCount,
     flowCount,
   };
+}
+
+export async function runParse(argv: string[]): Promise<ParseCommandResult> {
+  const filePath = argv[0];
+  if (!filePath) return fail('Usage: moment parse <file.moment>');
+
+  const resolvedPath = resolve(filePath);
+  if (!existsSync(resolvedPath)) return fail(`Error: File not found: ${resolvedPath}`);
+
+  const content = readFile(resolvedPath);
+  if (typeof content !== 'string') return content;
+
+  const parser = new MomentParser();
+  const result = await parser.parseContent(content);
+  return toResult(result);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,17 +15,22 @@ switch (command) {
     break;
   }
   case 'parse': {
-    runParse(args).then((result) => {
-      if (result.success) {
-        console.log(result.message);
-      } else {
-        console.error(result.message);
-        for (const d of result.diagnostics) {
-          console.error(formatDiagnostic(d));
+    runParse(args)
+      .then((result) => {
+        if (result.success) {
+          console.log(result.message);
+        } else {
+          console.error(result.message);
+          for (const d of result.diagnostics) {
+            console.error(formatDiagnostic(d));
+          }
+          process.exitCode = 1;
         }
+      })
+      .catch((error: unknown) => {
+        console.error('Error:', error instanceof Error ? error.message : String(error));
         process.exitCode = 1;
-      }
-    });
+      });
     break;
   }
   default:


### PR DESCRIPTION
## Summary

- Implements `moment parse` CLI command — delegates to MomentParser from @mmmnt/core (EXIT-C1)
- Handles valid .moment files (IR summary output), invalid files (diagnostic output), missing files, no arguments
- Diagnostics formatted with source location (file:line:col) per EXIT-C2
- Registers `parse` command in CLI entry point alongside `init`
- 6 tests using real fixture files from fixtures/valid/ and fixtures/invalid/

## Test plan

- [x] turbo run build --filter=@mmmnt/cli exits 0
- [x] turbo run lint --filter=@mmmnt/cli exits 0
- [x] turbo run test --filter=@mmmnt/cli exits 0 — 14 tests pass (6 new)

https://claude.ai/code/session_01GLiwcdChXCW4ZFsDx9L5LF