### PR TITLE
test(mcp): MCP integration test with InMemoryTransport (MMNT-264)

### DIFF
--- a/packages/mcp/src/__tests__/mcp-integration.spec.ts
+++ b/packages/mcp/src/__tests__/mcp-integration.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { resolve } from 'node:path';
+import { resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createMcpServer } from '../server.js';
@@ -14,6 +15,9 @@ import { createMcpServer } from '../server.js';
 const FIXTURES = resolve(import.meta.dirname, '../../../../fixtures');
 const VALID_FIXTURE = resolve(FIXTURES, 'valid/unified/vet-clinic.moment');
 const INVALID_FIXTURE = resolve(FIXTURES, 'invalid/no-declaration.moment');
+const NONEXISTENT_FILE = join(tmpdir(), `nonexistent-mcp-${Date.now()}.moment`);
+const NONEXISTENT_PROJECT = join(tmpdir(), `nonexistent-project-mcp-${Date.now()}`);
+const NONEXISTENT_DOMAIN = join(tmpdir(), `nonexistent-domain-mcp-${Date.now()}`);
 
 let client: Client;
 let clientTransport: InMemoryTransport;
@@ -30,8 +34,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await clientTransport.close();
-  await serverTransport.close();
+  await clientTransport?.close();
+  await serverTransport?.close();
 });
 
 describe('MCP Integration — tools/list', () => {
@@ -99,7 +103,7 @@ describe('MCP Integration — tools/call', () => {
   it('moment_validate with nonexistent file returns structured error (EXIT-B4)', async () => {
     const result = await client.callTool({
       name: 'moment_validate',
-      arguments: { filePath: '/tmp/nonexistent-mcp-test.moment' },
+      arguments: { filePath: NONEXISTENT_FILE },
     });
 
     expect(result.isError).toBe(true);
@@ -160,7 +164,7 @@ describe('MCP Integration — tools/call', () => {
   it('moment_get_events with nonexistent dir returns error or empty', async () => {
     const result = await client.callTool({
       name: 'moment_get_events',
-      arguments: { projectDir: '/tmp/nonexistent-project-mcp-test' },
+      arguments: { projectDir: NONEXISTENT_PROJECT },
     });
 
     const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
@@ -175,7 +179,7 @@ describe('MCP Integration — tools/call', () => {
   it('moment_import with nonexistent domain dir returns error', async () => {
     const result = await client.callTool({
       name: 'moment_import',
-      arguments: { domainDir: '/tmp/nonexistent-domain-mcp-test' },
+      arguments: { domainDir: NONEXISTENT_DOMAIN },
     });
 
     expect(result.isError).toBe(true);


### PR DESCRIPTION
## Summary
End-to-end integration tests for the MCP server using the MCP SDK's `Client` + `InMemoryTransport`. Verifies the full request/response cycle without stdio.

## Test Coverage
12 integration tests covering:
- **tools/list**: all 7 tools registered, each has description + input schema
- **tools/call**: validate (valid/invalid/missing), status, viz, emit-ts (dryRun), reconcile, get-events, import

## Exit criteria
- [x] EXIT-B1: `tools/list` returns all 7 tools
- [x] EXIT-B2: `moment_validate` with valid fixture → success
- [x] EXIT-B4: Invalid input → structured error (no crash)
- [x] EXIT-C1: Tests use MCP SDK test client (InMemoryTransport)
- [x] EXIT-C2: Server lifecycle managed via beforeAll/afterAll

## Test plan
- [x] 7 tool names match expected set
- [x] Descriptions are meaningful (>20 chars)
- [x] Input schemas have type: object
- [x] Valid validate → contextCount: 4, flowCount: 1
- [x] Invalid validate → diagnostics
- [x] Missing file → errorCode
- [x] Status → sections + hasDrift
- [x] Viz → envelope data
- [x] Emit-ts dryRun → fileList
- [x] Reconcile no .domain/ → NO_CHANGES
- [x] Get-events nonexistent → error/empty
- [x] Import nonexistent → error

https://claude.ai/code/session_01GLiwcdChXCW4ZFsDx9L5LF