### PR TITLE
docs: update all documentation for v1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 A DSL and toolchain for temporal DDD modeling.
 
-Moment transforms `.moment` specification files into typed TypeScript implementations, Gherkin test scenarios, and specification documents — creating a single source of truth for how bounded contexts communicate through time.
+Moment transforms `.moment` specification files into typed TypeScript implementations, Gherkin test scenarios, simulation topologies, and specification documents — creating a single source of truth for how bounded contexts communicate through time.
 
 ## Documentation
 
@@ -20,7 +20,7 @@ Full documentation is maintained in the **[Moment Wiki](https://github.com/mmmnt
 
 - **[Product Overview](https://github.com/mmmnt/mmmnt/wiki/Moment)** — What Moment does, design principles, DSL examples
 - **[Architecture](https://github.com/mmmnt/mmmnt/wiki/Architecture-Overview)** — Bounded context map, data flow
-- **[Pipeline](https://github.com/mmmnt/mmmnt/wiki/Pipeline)** — Reactive policy chain: parse → derive → [generate + emit-ts]
+- **[Pipeline](https://github.com/mmmnt/mmmnt/wiki/Pipeline)** — Reactive policy chain: parse → derive → [generate + emit-ts + topology]
 - **[Package Reference](https://github.com/mmmnt/mmmnt/wiki/Package-Reference)** — All packages with dependency graph
 - **[Contributing](https://github.com/mmmnt/mmmnt/wiki/Contributing)** — Setup, conventions, testing
 
@@ -28,10 +28,16 @@ Full documentation is maintained in the **[Moment Wiki](https://github.com/mmmnt
 
 | Package | Description |
 |---------|-------------|
-| [`@mmmnt/core`](https://github.com/mmmnt/mmmnt/wiki/@mmmnt-core) | Parser (Langium), IR, validators, manifest, Sift import |
-| [`@mmmnt/derive`](https://github.com/mmmnt/mmmnt/wiki/@mmmnt-derive) | DerivationEngine: IR → TestSuiteTopology |
-| [`@mmmnt/generate`](https://github.com/mmmnt/mmmnt/wiki/@mmmnt-generate) | GherkinGenerator + SpecDocGenerator → .feature, .md |
-| [`@mmmnt/emit-ts`](https://github.com/mmmnt/mmmnt/wiki/@mmmnt-emit-ts) | TypeScriptEmitter + TestScaffoldEmitter → .ts, .spec.ts |
+| [`@mmmnt/core`](packages/core) | Langium parser, AST-to-IR transform, manifest management, Sift import |
+| [`@mmmnt/derive`](packages/derive) | Test topology, simulation scenarios, event catalog, impact analysis, saga state machines, topology emitter |
+| [`@mmmnt/emit-ts`](packages/emit-ts) | TypeScript types, aggregates, test scaffolds |
+| [`@mmmnt/generate`](packages/generate) | Gherkin features, specification docs, AsyncAPI, Cucumber JSON |
+| [`@mmmnt/harness`](packages/harness) | TestRunner (structural validation for payload, saga, policy), EventReplayEngine, ContractAssertionEngine |
+| [`@mmmnt/schema`](packages/schema) | Schema lifecycle governance, codex rule evaluation |
+| [`@mmmnt/sync`](packages/sync) | AST diff engine, cascade reconciliation, Sift event watching |
+| [`@mmmnt/viz`](packages/viz) | Context map + timeline rendering, VizDataEnvelope, live preview server |
+| [`@mmmnt/cli`](packages/cli) | 20+ commands: parse, derive, generate, emit-ts, simulate, test, viz, lint, and more |
+| [`@mmmnt/mcp`](packages/mcp) | Model Context Protocol server (7 tools, fully offline) |
 
 ## Quick Start
 
@@ -47,6 +53,8 @@ pnpm turbo test
 
 | Tag | Milestone |
 |-----|-----------|
+| [`v1.0.0`](https://github.com/mmmnt/mmmnt/releases/tag/v1.0.0) | Stable — full pipeline, all 10 packages, structural saga/policy validation, topology emitter, Facet output pipeline |
+| [`v0.1.0-m6`](https://github.com/mmmnt/mmmnt/releases/tag/v0.1.0-m6) | Schema governance, viz, MCP server, sync |
 | [`v0.1.0-m3`](https://github.com/mmmnt/mmmnt/releases/tag/v0.1.0-m3) | Derivation + Generation Pipeline |
 | [`v0.1.0-m2`](https://github.com/mmmnt/mmmnt/releases/tag/v0.1.0-m2) | Specification Parsing |
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -89,12 +89,13 @@ moment watch specs/
 | Command | Description |
 |---------|-------------|
 | `moment derive <file>` | Derive test topologies, simulation scenarios, event catalogs, impact analysis, and saga state machines from a specification. |
-| `moment simulate <file>` | Run simulation scenarios against the specification and report event flow traces. |
+| `moment simulate <file>` | Run simulation scenarios against the specification and report event flow traces. Supports `--all` to generate all branch combinations plus negative (precondition violation) scenarios, and `--out-dir <path>` to write per-flow topology files, individual scenario files, `manifest.json`, and ADR-029 artifacts (`event-catalog.json`, `impact-analysis.json`, `saga-state-machines.json`, `asyncapi.yaml`). |
 
 ### Code Generation
 
 | Command | Description |
 |---------|-------------|
+| `moment cucumber-json <file>` | Output Cucumber JSON to stdout for Xray import. Useful for integrating Moment-derived scenarios into Jira/Xray test management workflows. |
 | `moment emit-ts <file>` | Generate TypeScript interfaces, aggregate root classes, discriminated event union types, and test scaffold files from the specification. |
 | `moment generate <file>` | Generate Gherkin `.feature` files, a `specification.md` document with Mermaid diagrams, and an `asyncapi.yaml` specification. |
 

--- a/packages/derive/README.md
+++ b/packages/derive/README.md
@@ -72,6 +72,7 @@ for (const scenario of scenarios) {
 | `generateEventCatalog(ir)` | Builds a catalog of every event with producer/consumer context, payload schema, and flow participation. |
 | `generateImpactAnalysis(ir)` | Produces a dependency graph showing how changes to one context or event propagate across the system. |
 | `generateSagaStateMachines(ir)` | Extracts saga state machines from multi-step flows, with states and transitions. |
+| `TopologyEmitter` | Class that produces a `SimulationTopology` per flow, containing lanes, frames, connections, eventRouting, branchPredicates, and contextMap. |
 
 ### Policies
 
@@ -91,15 +92,23 @@ for (const scenario of scenarios) {
 | `PayloadValidationStep` | A constraint on event or command payload fields. |
 | `FieldConstraint` | A validation rule for a single field within a payload. |
 | `TopologyMetadata` | Metadata about the derived topology including source specification and derivation timestamp. |
-| `SimulationScenario` | A simulation run with ordered events and active branches. |
+| `SimulationScenario` | A simulation run with ordered events and active branches. Includes `flowId: string` and `flowName: string` identifying the source flow. |
 | `SimulationEvent` | A single event within a simulation scenario. |
 | `ActiveBranch` | A branch condition active during a simulation. |
 | `SimulationOptions` | Options controlling simulation scope and behavior. |
 | `EventCatalog` / `EventCatalogEntry` | Catalog of events with producer/consumer metadata. |
 | `ImpactAnalysis` / `ImpactNode` | Directed graph of impact propagation across contexts. |
-| `SagaStateMachine` | State machine with states and transitions extracted from flows. |
+| `SagaStateMachine` | State machine with states and transitions extracted from flows. Includes `earlyExitStates: readonly string[]` listing states from which the saga may exit early (any state that is neither initial nor final). |
 | `SagaState` | A single state within a saga state machine. |
 | `SagaTransition` | A transition between saga states, triggered by an event. |
+| `SimulationTopology` | Complete topology for a single flow, produced by `TopologyEmitter`. Contains lanes, frames, connections, eventRouting, branchPredicates, and contextMap. |
+| `TopologyLane` | A lane within a simulation topology, representing a bounded context or actor. |
+| `TopologyFrame` | A frame grouping related nodes within a topology lane. |
+| `TopologyNode` | A single node (command, event, or policy) within a topology frame. |
+| `TopologyConnection` | A directed connection between two topology nodes. |
+| `TopologyBranchPredicate` | A predicate describing a branching condition within the topology. |
+| `TopologyContextMap` | A mapping of context relationships and dependencies within the topology. |
+| `TopologySchemaContract` | A schema contract describing the payload shape exchanged between topology nodes. |
 
 ## Examples
 

--- a/packages/generate/README.md
+++ b/packages/generate/README.md
@@ -76,6 +76,10 @@ for (const feature of features) {
 - **Event catalog** table with producers, consumers, and payload summaries
 - **Glossary** of domain terms extracted from the specification
 
+### Cucumber JSON
+
+- Cucumber JSON output is available via `generateCucumberJson` for CI/QMS integration, enabling direct import into tools like Xray for test management and traceability reporting.
+
 ### AsyncAPI Specification
 
 - Standards-compliant AsyncAPI 3.0 YAML
@@ -93,6 +97,7 @@ for (const feature of features) {
 | `renderFeatureFromIr(ir)` | Lower-level function that renders a single feature from IR data without requiring a topology. |
 | `SpecificationDocumentGenerator` | Produces a Markdown specification document with embedded Mermaid diagrams covering context maps, flows, and event catalogs. |
 | `generateAsyncApiSpec(ir)` | Generates an AsyncAPI 3.0 YAML specification from the IR with channels, messages, and payload schemas. |
+| `generateCucumberJson(manifest, topology, ir)` | Converts Gherkin features and test topology into Cucumber JSON format for Xray import and CI/QMS integration. |
 
 ### Policies
 
@@ -107,6 +112,9 @@ for (const feature of features) {
 | `GeneratedFeatureFile` | A generated `.feature` file with path and content. |
 | `GeneratedDocument` | A generated document with path, content, and format metadata. |
 | `GenerationManifest` | Summary of all generated artifacts from a single run, with file counts and paths. |
+| `CucumberFeature` | Represents a single Cucumber JSON feature object with scenarios and metadata. |
+| `CucumberScenario` | Represents a scenario within a Cucumber JSON feature, including steps and tags. |
+| `CucumberStep` | Represents an individual Given/When/Then step within a Cucumber JSON scenario. |
 
 ## Examples
 

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -56,6 +56,8 @@ for (const result of results) {
 - **Aggregate factory support** -- supply your own aggregate factory functions to replay events against real implementations rather than stubs.
 - **Severity-graded violations** -- contract violations are graded by severity (error, warning, info) so teams can prioritize fixes.
 - **Source location tracking** -- violations include the source location in your implementation code for quick navigation.
+- **Structural saga validation (TE-03)** -- dispatches on `assertionType: 'saga'` to validate that the trigger event exists in the IR, that states are adjacent in the saga chain, and that both the compensation string and timeout are defined.
+- **Structural policy chain validation (TE-04)** -- dispatches on `assertionType: 'policy-chain'` to validate that the trigger event exists in the IR and that the `chainsTo` command exists in the IR.
 - **CI/CD integration** -- structured output and standard exit codes make the harness suitable for automated pipeline gates.
 
 ## API Reference
@@ -64,7 +66,7 @@ for (const result of results) {
 
 | Export | Description |
 |--------|-------------|
-| `TestRunner` | Orchestrates test suite execution against implementations. Manages setup steps, runs assertions, and aggregates results into `TestRunResult`. |
+| `TestRunner` | Orchestrates test suite execution against implementations. Dispatches on `assertionType` from each test case's assertions, routing to separate evaluation paths for `'saga'`, `'policy-chain'`, and `'payload'` assertion types. Manages setup steps, runs assertions, and aggregates results into `TestRunResult`. |
 
 ### Event Replay
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,11 +2,13 @@
   "$schema": "https://typedoc.org/schema.json",
   "entryPointStrategy": "packages",
   "entryPoints": [
+    "packages/cli",
     "packages/core",
     "packages/derive",
     "packages/emit-ts",
     "packages/generate",
     "packages/harness",
+    "packages/mcp",
     "packages/schema",
     "packages/sync",
     "packages/viz"


### PR DESCRIPTION
## Summary

Comprehensive documentation update for v1.0.0 release. All READMEs, API docs config, and release information brought up to date with current capabilities.

### Changes

**Root README.md**
- Expanded packages table from 4 to all 10 packages with descriptions
- Added v1.0.0 and v0.1.0-m6 to releases table
- Updated pipeline description to include topology emission
- Linked packages to local directories

**@mmmnt/derive README**
- Added `TopologyEmitter` class + 8 topology types to API reference
- Updated `SimulationScenario` docs with `flowId`/`flowName` fields
- Updated `SagaStateMachine` docs with `earlyExitStates` field

**@mmmnt/generate README**
- Added `generateCucumberJson` function to API reference
- Added `CucumberFeature`/`CucumberScenario`/`CucumberStep` types
- Added Cucumber JSON section to Generated Output

**@mmmnt/cli README**
- Added `moment cucumber-json` command
- Updated `moment simulate` with `--all` and `--out-dir` flags

**@mmmnt/harness README**
- Added structural saga validation (TE-03) to Key Features
- Added structural policy chain validation (TE-04) to Key Features
- Updated TestRunner description with assertionType dispatch

**typedoc.json**
- Added `@mmmnt/cli` and `@mmmnt/mcp` to entryPoints (8 → 10 packages)

### Verification

1053/1053 tests passing, 21/21 E2E.

https://claude.ai/code/session_01MEhSFSV2wkYRrdeJpWLLu4