### PR TITLE
fix: path-traversal guard on moment simulate --out-dir

### DIFF
--- a/packages/cli/src/commands/import-from-sift.ts
+++ b/packages/cli/src/commands/import-from-sift.ts
@@ -15,6 +15,7 @@ import { SiftSpecificationImporter } from '@mmmnt/core';
 import { SiftEventStreamReader } from '@mmmnt/sync';
 import type { Diagnostic } from '@mmmnt/core';
 import type { SiftImportInput } from '@mmmnt/core';
+import { assertPathWithin } from './project-fs.js';
 
 export interface ImportResult {
   readonly success: boolean;
@@ -51,7 +52,11 @@ export async function runImportFromSift(argv: string[]): Promise<ImportResult> {
   return executeImport(resolvedDir, values['output-dir'], values.json === true);
 }
 
-function executeImport(domainDir: string, outputDir: string | undefined, asJson: boolean): ImportResult {
+function executeImport(
+  domainDir: string,
+  outputDir: string | undefined,
+  asJson: boolean,
+): ImportResult {
   // Read and replay JSONL event stream
   const reader = new SiftEventStreamReader();
   const readResult = reader.read(domainDir);
@@ -72,27 +77,40 @@ function executeImport(domainDir: string, outputDir: string | undefined, asJson:
 
   if (importResult.diagnostics.some((d) => d.severity === 'error')) {
     const errorCount = importResult.diagnostics.filter((d) => d.severity === 'error').length;
-    return { success: false, message: `Import failed with ${errorCount} error(s)`, diagnostics: importResult.diagnostics, filesWritten: 0, eventsProcessed: readResult.eventsProcessed };
+    return {
+      success: false,
+      message: `Import failed with ${errorCount} error(s)`,
+      diagnostics: importResult.diagnostics,
+      filesWritten: 0,
+      eventsProcessed: readResult.eventsProcessed,
+    };
   }
 
   const outDir = resolve(outputDir ?? dirname(domainDir));
   const filesWritten = writeOutputFiles(importer, siftInput, outDir);
   writeFingerprint(siftInput, importResult, domainDir, outDir);
 
-  return buildResult(importResult, filesWritten, readResult.eventsProcessed, readResult.filesRead, asJson);
+  return buildResult(
+    importResult,
+    filesWritten,
+    readResult.eventsProcessed,
+    readResult.filesRead,
+    asJson,
+  );
 }
 
 function sanitizeFileName(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
 }
 
-function assertPathWithin(filePath: string, baseDir: string): void {
-  if (!resolve(filePath).startsWith(resolve(baseDir))) {
-    throw new Error(`Path traversal detected: ${filePath} escapes ${baseDir}`);
-  }
-}
-
-function writeOutputFiles(importer: SiftSpecificationImporter, input: SiftImportInput, outDir: string): number {
+function writeOutputFiles(
+  importer: SiftSpecificationImporter,
+  input: SiftImportInput,
+  outDir: string,
+): number {
   let count = 0;
   const momentDir = join(outDir, '.moment');
 
@@ -121,7 +139,9 @@ function writeFingerprint(
   // Idempotent: skip write if content unchanged (EXIT-C4)
   if (existsSync(fpPath)) {
     try {
-      const existing = JSON.parse(readFileSync(fpPath, 'utf-8')) as { sift?: { contentHash?: string } };
+      const existing = JSON.parse(readFileSync(fpPath, 'utf-8')) as {
+        sift?: { contentHash?: string };
+      };
       if (existing.sift?.contentHash === contentHash) return;
     } catch {
       // Unreadable — overwrite
@@ -145,7 +165,9 @@ function writeFingerprint(
 
 function computeDomainHash(domainDir: string): string {
   const { readdirSync } = require('node:fs') as typeof import('node:fs');
-  const files = readdirSync(domainDir).filter((f: string) => f.endsWith('.jsonl')).sort();
+  const files = readdirSync(domainDir)
+    .filter((f: string) => f.endsWith('.jsonl'))
+    .sort();
   const hash = createHash('sha256');
   for (const file of files) {
     hash.update(readFileSync(join(domainDir, file), 'utf-8'));
@@ -158,8 +180,10 @@ function countAggregates(input: SiftImportInput): number {
 }
 
 function countDomainEvents(input: SiftImportInput): number {
-  return input.buildingBlocks.reduce((sum, b) =>
-    sum + b.aggregates.reduce((s, a) => s + a.events.length, 0), 0);
+  return input.buildingBlocks.reduce(
+    (sum, b) => sum + b.aggregates.reduce((s, a) => s + a.events.length, 0),
+    0,
+  );
 }
 
 function buildResult(
@@ -179,7 +203,14 @@ function buildResult(
 
   if (asJson) {
     const json = JSON.stringify(summary, null, 2);
-    return { success: true, message: json, diagnostics: importResult.diagnostics, filesWritten, eventsProcessed, json };
+    return {
+      success: true,
+      message: json,
+      diagnostics: importResult.diagnostics,
+      filesWritten,
+      eventsProcessed,
+      json,
+    };
   }
 
   return {

--- a/packages/cli/src/commands/project-fs.ts
+++ b/packages/cli/src/commands/project-fs.ts
@@ -45,8 +45,14 @@ export function resolveOutputBaseDir(sourceFilePath: string, explicitOut?: strin
  * Assert that `candidatePath` resolves to a location inside `baseDir`.
  * Uses a path-separator boundary check so that `/base-other/foo` is not
  * treated as being inside `/base`.
+ *
+ * Exported for reuse across writer commands (generate, emit-ts, simulate,
+ * import-from-sift, serve facet-dir mode). Any command that writes files
+ * whose paths are derived from user-controlled content in a `.moment`
+ * spec or manifest should guard the resolved path with this before
+ * calling writeFileSync.
  */
-function assertPathWithin(candidatePath: string, baseDir: string): void {
+export function assertPathWithin(candidatePath: string, baseDir: string): void {
   const resolvedBase = resolve(baseDir);
   const resolvedCandidate = resolve(candidatePath);
   const baseWithSep = resolvedBase.endsWith(sep) ? resolvedBase : resolvedBase + sep;

--- a/packages/cli/src/commands/simulate.test.ts
+++ b/packages/cli/src/commands/simulate.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runSimulate } from './simulate.js';
+
+// A self-contained minimal .moment flow that parses successfully against
+// the live grammar. The $NAME placeholder is replaced per-test so each
+// case can use its own flow name to probe traversal behavior without
+// mutating a checked-in fixture.
+const FLOW_TEMPLATE = `flow $NAME
+  description "smoke"
+
+  lane ordering "Ordering" [Core]
+  lane fulfillment "Fulfillment" [Supporting]
+
+  moment "Order submission"
+    ordering: PlaceOrder
+    ordering: OrderPlaced crosses-to fulfillment via CustomerSupplier
+      contract
+        orderId: UUID [required]
+
+  moment "Fulfillment initiation"
+    fulfillment: InitiateFulfillment
+      triggered-by OrderPlaced
+    fulfillment: FulfillmentInitiated
+`;
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'moment-simulate-trav-'));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+function writeSpec(name: string): string {
+  const spec = FLOW_TEMPLATE.replace('$NAME', name);
+  const specPath = join(workDir, 'flow.moment');
+  writeFileSync(specPath, spec, 'utf-8');
+  return specPath;
+}
+
+describe('moment simulate path-traversal guard', () => {
+  it('writes scenario files under --out-dir for a normal flow name', async () => {
+    const specPath = writeSpec('"order-placed"');
+    const outDir = join(workDir, 'out');
+    const result = await runSimulate([specPath, '--all', '--out-dir', outDir]);
+
+    expect(result.success).toBe(true);
+    expect(existsSync(outDir)).toBe(true);
+    const files = readdirSync(outDir);
+    expect(files.some((f) => f.startsWith('topology-') && f.endsWith('.json'))).toBe(true);
+    expect(files.some((f) => f.startsWith('scenario-') && f.endsWith('.json'))).toBe(true);
+    expect(files).toContain('manifest.json');
+  });
+
+  it('rejects a flow name crafted to escape --out-dir via ../', async () => {
+    // Enough `../` segments to climb above the tmpdir's workDir and out/
+    // subdir. The first `scenario-flow-..` directory absorbs one `..` during
+    // path.join normalization, so you need N+2 `..` to escape by N levels.
+    const specPath = writeSpec('"../../../../../../../../../tmp/pwned-by-simulate-test"');
+    const outDir = join(workDir, 'out');
+
+    const result = await runSimulate([specPath, '--all', '--out-dir', outDir]);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/Path traversal detected/);
+    // And crucially: no file was written outside outDir.
+    expect(existsSync(resolve('/tmp/pwned-by-simulate-test.json'))).toBe(false);
+  });
+
+  // NOTE: absolute paths in flow names are NOT a traversal vector via this
+  // code path. `path.join(outDir, '/tmp/foo.json')` doesn't treat the leading
+  // slash as "start from root" — it treats the whole string as a relative
+  // segment, producing `<outDir>/tmp/foo.json`. The attack only works via
+  // `../` climb-out sequences (tested above). Documenting the non-threat
+  // here so a future reader doesn't reintroduce an absolute-path test that
+  // fails for the wrong reason (ENOENT on a deeply nested subdir).
+});

--- a/packages/cli/src/commands/simulate.test.ts
+++ b/packages/cli/src/commands/simulate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { runSimulate } from './simulate.js';
 
@@ -58,18 +58,29 @@ describe('moment simulate path-traversal guard', () => {
   });
 
   it('rejects a flow name crafted to escape --out-dir via ../', async () => {
-    // Enough `../` segments to climb above the tmpdir's workDir and out/
-    // subdir. The first `scenario-flow-..` directory absorbs one `..` during
-    // path.join normalization, so you need N+2 `..` to escape by N levels.
-    const specPath = writeSpec('"../../../../../../../../../tmp/pwned-by-simulate-test"');
+    // Craft a flow name that escapes exactly one level out of outDir into
+    // the test workDir. The first `scenario-flow-..` directory segment
+    // absorbs one `..` during path.join normalization, so THREE `..`
+    // segments climb: one to cancel scenario-flow-.., one to climb out of
+    // outDir's parent (workDir/out → workDir), one more kept by the path
+    // renderer. Then 'escaped/sentinel.json' lands at
+    // <workDir>/escaped/sentinel.json — outside outDir but inside the
+    // temp workspace so the test is hermetic and cross-platform.
+    const specPath = writeSpec('"../../../escaped/sentinel"');
     const outDir = join(workDir, 'out');
+    // This is the path the exploit would write to if the guard were
+    // absent. It's derived from workDir so tests don't collide across
+    // runners or touch any global filesystem state.
+    const escapeTarget = join(workDir, 'escaped', 'sentinel.json');
 
     const result = await runSimulate([specPath, '--all', '--out-dir', outDir]);
 
     expect(result.success).toBe(false);
     expect(result.message).toMatch(/Path traversal detected/);
-    // And crucially: no file was written outside outDir.
-    expect(existsSync(resolve('/tmp/pwned-by-simulate-test.json'))).toBe(false);
+    // Crucial assertion: nothing was written at the escape path.
+    expect(existsSync(escapeTarget)).toBe(false);
+    // And no `escaped/` sibling directory was created next to outDir.
+    expect(existsSync(join(workDir, 'escaped'))).toBe(false);
   });
 
   // NOTE: absolute paths in flow names are NOT a traversal vector via this

--- a/packages/cli/src/commands/simulate.ts
+++ b/packages/cli/src/commands/simulate.ts
@@ -114,11 +114,14 @@ interface ManifestScenario {
 /**
  * Write a file into `baseDir`, guarding against path traversal.
  *
- * The filename may include user-controlled substrings (e.g. `scenario-${scenarioId}.json`
- * where scenarioId is derived from `flow.id` which is `flow-${flow.name}` and flow.name
- * is a langium STRING — arbitrary content). Without this guard, a `.moment` file
- * declaring `flow "../../etc/evil"` would write outside `baseDir`. `assertPathWithin`
- * rejects any resolved target that falls outside the directory using a path-separator
+ * The filename may include user-controlled substrings. Concretely, scenario
+ * files are written as `${scenario.scenarioId}.json` where `scenarioId` is
+ * built by the derive package as `scenario-${flow.id}` and `flow.id` is
+ * `flow-${flow.name}`. `flow.name` is a langium STRING with no character
+ * restrictions, so a `.moment` file declaring `flow "../../etc/evil"`
+ * produces a filename containing `../` segments that `path.join` would
+ * normalize through, escaping `baseDir`. `assertPathWithin` rejects any
+ * resolved target that falls outside the directory using a path-separator
  * boundary check (so `/base-sibling` can't masquerade as inside `/base`).
  */
 function writeSafe(baseDir: string, filename: string, content: string): void {

--- a/packages/cli/src/commands/simulate.ts
+++ b/packages/cli/src/commands/simulate.ts
@@ -10,7 +10,7 @@
  * --flow <name>: filter to a specific flow
  */
 
-import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { parseArgs } from 'node:util';
 import { MomentParser } from '@mmmnt/core';
@@ -27,6 +27,7 @@ import {
 import type { SimulationScenario } from '@mmmnt/derive';
 import { generateAsyncApiSpec } from '@mmmnt/generate';
 import { updateManifestFromIr } from './update-manifest.js';
+import { assertPathWithin } from './project-fs.js';
 
 export interface SimulateCommandResult {
   readonly success: boolean;
@@ -110,6 +111,22 @@ interface ManifestScenario {
   isNegative: boolean;
 }
 
+/**
+ * Write a file into `baseDir`, guarding against path traversal.
+ *
+ * The filename may include user-controlled substrings (e.g. `scenario-${scenarioId}.json`
+ * where scenarioId is derived from `flow.id` which is `flow-${flow.name}` and flow.name
+ * is a langium STRING — arbitrary content). Without this guard, a `.moment` file
+ * declaring `flow "../../etc/evil"` would write outside `baseDir`. `assertPathWithin`
+ * rejects any resolved target that falls outside the directory using a path-separator
+ * boundary check (so `/base-sibling` can't masquerade as inside `/base`).
+ */
+function writeSafe(baseDir: string, filename: string, content: string): void {
+  const fullPath = join(baseDir, filename);
+  assertPathWithin(fullPath, baseDir);
+  writeFileSync(fullPath, content, 'utf-8');
+}
+
 function writeOutputFiles(
   groups: FlowScenarioGroup[],
   ir: IntermediateRepresentation,
@@ -126,20 +143,19 @@ function writeOutputFiles(
   for (const group of groups) {
     const flowSlug = kebab(group.flow.name);
 
-    // Write topology for this flow
+    // Write topology for this flow. flowSlug is kebab-sanitized so traversal
+    // is impossible here, but writeSafe is used uniformly for consistency.
     const topology = topoEmitter.emit(ir, group.flow);
     const topologyFile = `topology-${flowSlug}.json`;
-    writeFileSync(
-      join(resolvedDir, topologyFile),
-      JSON.stringify(topology, null, 2) + '\n',
-      'utf-8',
-    );
+    writeSafe(resolvedDir, topologyFile, JSON.stringify(topology, null, 2) + '\n');
 
-    // Write each scenario
+    // Write each scenario. scenarioId is NOT kebab-sanitized and may contain
+    // raw user content via flow.name → flow.id → `scenario-${flow.id}`, so
+    // writeSafe's path-traversal guard is load-bearing here.
     const manifestScenarios: ManifestScenario[] = [];
     for (const scenario of group.scenarios) {
       const fileName = `${scenario.scenarioId}.json`;
-      writeFileSync(join(resolvedDir, fileName), JSON.stringify(scenario, null, 2) + '\n', 'utf-8');
+      writeSafe(resolvedDir, fileName, JSON.stringify(scenario, null, 2) + '\n');
       totalScenarios++;
       totalEvents += scenario.events.length;
 
@@ -167,12 +183,11 @@ function writeOutputFiles(
   // Write spec-level artifacts (ADR-029 §3)
   const artifacts = writeArtifacts(ir, resolvedDir);
 
+  // Manifest filename is hardcoded, so path traversal is impossible, but
+  // keep writeSafe uniform so future refactors don't accidentally introduce
+  // a writeFileSync that forgets the guard.
   const manifest = { flows: manifestFlows, artifacts };
-  writeFileSync(
-    join(resolvedDir, 'manifest.json'),
-    JSON.stringify(manifest, null, 2) + '\n',
-    'utf-8',
-  );
+  writeSafe(resolvedDir, 'manifest.json', JSON.stringify(manifest, null, 2) + '\n');
 
   return {
     success: true,
@@ -186,27 +201,19 @@ function writeArtifacts(ir: IntermediateRepresentation, outDir: string): Record<
 
   const catalog = generateEventCatalog(ir);
   files.eventCatalog = 'event-catalog.json';
-  writeFileSync(join(outDir, files.eventCatalog), JSON.stringify(catalog, null, 2) + '\n', 'utf-8');
+  writeSafe(outDir, files.eventCatalog, JSON.stringify(catalog, null, 2) + '\n');
 
   const impact = generateImpactAnalysis(ir);
   files.impactAnalysis = 'impact-analysis.json';
-  writeFileSync(
-    join(outDir, files.impactAnalysis),
-    JSON.stringify(impact, null, 2) + '\n',
-    'utf-8',
-  );
+  writeSafe(outDir, files.impactAnalysis, JSON.stringify(impact, null, 2) + '\n');
 
   const sagas = generateSagaStateMachines(ir);
   files.sagaStateMachines = 'saga-state-machines.json';
-  writeFileSync(
-    join(outDir, files.sagaStateMachines),
-    JSON.stringify(sagas, null, 2) + '\n',
-    'utf-8',
-  );
+  writeSafe(outDir, files.sagaStateMachines, JSON.stringify(sagas, null, 2) + '\n');
 
   const asyncapi = generateAsyncApiSpec(ir);
   files.asyncApi = 'asyncapi.yaml';
-  writeFileSync(join(outDir, files.asyncApi), asyncapi, 'utf-8');
+  writeSafe(outDir, files.asyncApi, asyncapi);
 
   return files;
 }
@@ -216,6 +223,33 @@ function kebab(s: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');
+}
+
+/**
+ * Run simulate in --out-dir mode. Builds the scenario groups and delegates
+ * to writeOutputFiles, catching any path-traversal error from assertPathWithin
+ * so the CLI returns a structured failure instead of crashing with an
+ * unhandled stack trace.
+ */
+function runOutDirWrite(
+  flows: FlowDefinition[],
+  ir: IntermediateRepresentation,
+  outDir: string,
+  includeAll: boolean,
+): SimulateCommandResult {
+  const groups: FlowScenarioGroup[] = flows.map((flow) => ({
+    flow,
+    scenarios: includeAll
+      ? [...generateAllScenarios(ir, flow), ...deriveNegativeScenarios(ir, flow)]
+      : [generateSimulationScenario(ir, flow)],
+  }));
+
+  try {
+    return writeOutputFiles(groups, ir, outDir);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return fail(msg);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -272,13 +306,7 @@ export async function runSimulate(argv: string[]): Promise<SimulateCommandResult
   const outDir = values['out-dir'];
 
   if (outDir) {
-    const groups: FlowScenarioGroup[] = targetFlows.map((flow) => ({
-      flow,
-      scenarios: values.all
-        ? [...generateAllScenarios(ir, flow), ...deriveNegativeScenarios(ir, flow)]
-        : [generateSimulationScenario(ir, flow)],
-    }));
-    return writeOutputFiles(groups, ir, outDir);
+    return runOutDirWrite(targetFlows, ir, outDir, values.all === true);
   }
 
   const scenarios: SimulationScenario[] = values.all


### PR DESCRIPTION
## TL;DR

`moment simulate --out-dir <dir>` shipped with a real path-traversal vulnerability. A `.moment` file declaring a flow name with `../` climbs could write scenario JSON files outside the `--out-dir`. Verified the exploit against `@mmmnt/cli@0.3.0` (current on npm) and fixed.

Closes **P2 #5** from the post-mortem: audit writer commands for the same shape that was fixed in `writeOutputFiles` (#136) and `serve` directory mode (#139).

## The bug

`scripts/moment simulate --out-dir` builds scenario filenames as:

```
scenarioId = `scenario-${flow.id}` = `scenario-flow-${flow.name}`
fileName   = `${scenarioId}.json`
writePath  = join(outDir, fileName)    // ← traversal happens here
```

`flow.name` is a langium `STRING` in the grammar (`'flow' name=STRING`) with **no character restrictions**. `unquote()` in `ast-to-ir.ts` just strips the surrounding `"…"` without sanitization. So a `.moment` file with:

```
flow "../../../../../../../../tmp/pwned"
  ...
```

produces a filename containing enough `../` segments to climb out of the `--out-dir`, and `path.join` normalizes them through.

### Exploit verified against pre-fix 0.3.0

```bash
$ sed 's|"order-placed"|"../../../../../../../../tmp/pwned"|' \
    fixtures/valid/minimal/flows/order-placed.moment > evil.moment

$ node packages/cli/dist/moment.mjs simulate evil.moment --out-dir /tmp/trav/out
(wrote /tmp/pwned.json — escaped out/)
```

The topology filename was safe because it uses `kebab(flow.name)` which strips non-alphanumerics. The scenario filename was NOT because it uses the raw `flow.id`.

### Post-fix

```bash
$ node packages/cli/dist/moment.mjs simulate evil.moment --out-dir /tmp/trav/out
Error: Path traversal detected: /tmp/pwned.json escapes output directory /tmp/trav/out
```

No file at `/tmp/pwned.json`. Clean structured error via `runSimulate`.

## What changed

| File | Change |
| --- | --- |
| `packages/cli/src/commands/project-fs.ts` | **Exported** the robust `assertPathWithin` helper. Uses a path-separator boundary check so `/base-sibling` can't masquerade as inside `/base`. Previously private to this file. |
| `packages/cli/src/commands/simulate.ts` | New local `writeSafe(baseDir, filename, content)` helper that calls `assertPathWithin` before `writeFileSync`. Every write in `writeOutputFiles` and `writeArtifacts` now goes through it. `runSimulate`'s `--out-dir` branch extracted into `runOutDirWrite` which catches the throw and returns a structured failure. |
| `packages/cli/src/commands/simulate.test.ts` | **New file**. Three tests: happy path writes scenarios inside `--out-dir`; crafted flow name with enough `../` rejected with "Path traversal detected"; documentation note explaining why absolute-path flow names aren't a traversal vector via this code path (path.join doesn't treat leading `/` as root). |
| `packages/cli/src/commands/import-from-sift.ts` | Replaced the **private** `assertPathWithin` (naive `startsWith`, vulnerable to `/base-other` prefix attack) with the shared import. `sanitizeFileName` defends in practice, but using the robust helper removes the latent risk. |

## What didn't change

- **`serve.ts`** — its `resolveWithinFacetDir` has a facet-specific error message that's more useful than the generic one from `assertPathWithin`, and the boundary logic is identical. Dedup for dedup's sake isn't worth the churn.
- **`reconcile.ts`** — its writes use hardcoded filenames (`manifest.json`, `event-catalog.json`, `.upstream-fingerprint.json`) or timestamp-derived names. No user-controlled paths. Clean.
- **`sync-accept.ts` / `sync-propose.ts`** — these have a *different* bug (they claim success without writing anything at all — P1 #3 from the post-mortem, still awaiting your decision on Option A/B/C). Not in scope for this PR.

## Test plan

- [x] 176/176 CLI unit tests pass (2 new)
- [x] `pnpm --filter @mmmnt/cli lint` clean
- [x] Exploit reproduction against pre-fix build: confirmed `/tmp/pwned.json` was written
- [x] Exploit reproduction against post-fix build: confirmed blocked with clean error
- [ ] CI + pack-and-install smoke test (from #144) pass on this PR

## Progress on the list

| Item | Status |
|---|---|
| P1 #2 audit-deps | ✅ (#143) |
| P1 #3 sync/reconcile | ⏸️ awaiting decision |
| P1 #4 pack-and-install | ✅ (#144) |
| **P2 #5 path-traversal** | **this PR** |
| P2 #6 ManifestReader validation | next |
| P2 #7 README drift | next |
