### PR TITLE
fix(core): reject absolute/escaping paths in manifest fields

### DIFF
--- a/.changeset/manifest-reader-path-traversal-guard.md
+++ b/.changeset/manifest-reader-path-traversal-guard.md
@@ -1,0 +1,31 @@
+---
+'@mmmnt/core': patch
+---
+
+**fix(core): reject absolute / escaping paths in manifest fields**
+
+`ManifestReader` now validates that `generators[].outputDir`,
+`contexts[].path`, and `flows[].path` in a `.manifest.yaml` are relative
+paths that stay inside the manifest directory. Previously any of these
+fields could be an absolute path (`/etc/evil`) or use `../` to climb
+outside the project, and downstream consumers would honor them:
+
+- A malicious `outputDir` would make `moment generate` / `moment emit-ts`
+  write outside the project (path-traversal write).
+- A malicious `contexts[].path` / `flows[].path` would make the parser
+  read and interpret arbitrary files as `.moment` specs.
+
+Both are now rejected at manifest-load time with a clear diagnostic
+pointing at the specific field:
+
+```
+Manifest validation failed: generators[0].outputDir '/etc/evil' must be
+a relative path (absolute paths are rejected).
+```
+
+The boundary check uses a path-separator boundary so `/base-sibling`
+can't masquerade as being inside `/base` — same shape as the guard in
+`@mmmnt/cli`'s `project-fs.ts`, duplicated locally because `@mmmnt/core`
+cannot depend on `@mmmnt/cli`.
+
+Closes P2 #6 from the post-mortem.

--- a/packages/core/__tests__/manifest/manifest-reader.spec.ts
+++ b/packages/core/__tests__/manifest/manifest-reader.spec.ts
@@ -267,6 +267,109 @@ flows:
     });
   });
 
+  describe('path-traversal guard on manifest fields', () => {
+    it('rejects an absolute generators[].outputDir', () => {
+      const manifestPath = writeManifest(`
+name: TestProject
+version: "1.0.0"
+generators:
+  - format: typescript
+    outputDir: /etc/evil
+`);
+      expect(() => reader.readManifest(manifestPath)).toThrow(
+        /generators\[0\]\.outputDir '\/etc\/evil' must be a relative path/,
+      );
+    });
+
+    it('rejects a generators[].outputDir that escapes the manifest dir via ../', () => {
+      const manifestPath = writeManifest(`
+name: TestProject
+version: "1.0.0"
+generators:
+  - format: gherkin
+    outputDir: ../../../outside
+`);
+      expect(() => reader.readManifest(manifestPath)).toThrow(
+        /generators\[0\]\.outputDir '\.\.\/\.\.\/\.\.\/outside' escapes the manifest directory/,
+      );
+    });
+
+    it('accepts a relative generators[].outputDir that stays inside the manifest dir', () => {
+      const manifestPath = writeManifest(`
+name: TestProject
+version: "1.0.0"
+generators:
+  - format: typescript
+    outputDir: src/generated
+`);
+      const result = reader.readManifest(manifestPath);
+      expect(result.generators).toEqual([{ format: 'typescript', outputDir: 'src/generated' }]);
+    });
+
+    it('allows empty/missing outputDir (defaults to empty string)', () => {
+      const manifestPath = writeManifest(`
+name: TestProject
+version: "1.0.0"
+generators:
+  - format: markdown
+`);
+      const result = reader.readManifest(manifestPath);
+      expect(result.generators[0].outputDir).toBe('');
+    });
+
+    it('rejects an absolute contexts[].path', () => {
+      const manifestPath = writeManifest(`
+name: TestProject
+version: "1.0.0"
+contexts:
+  - name: Evil
+    path: /etc/passwd
+`);
+      expect(() => reader.readManifest(manifestPath)).toThrow(
+        /contexts\[0\]\.path '\/etc\/passwd' must be a relative path/,
+      );
+    });
+
+    it('rejects a contexts[].path that escapes the manifest dir via ../', () => {
+      const manifestPath = writeManifest(`
+name: TestProject
+version: "1.0.0"
+contexts:
+  - name: Escape
+    path: ../../../etc/passwd
+`);
+      expect(() => reader.readManifest(manifestPath)).toThrow(
+        /contexts\[0\]\.path '\.\.\/\.\.\/\.\.\/etc\/passwd' escapes the manifest directory/,
+      );
+    });
+
+    it('rejects an absolute flows[].path', () => {
+      const manifestPath = writeManifest(`
+name: TestProject
+version: "1.0.0"
+flows:
+  - name: Evil
+    path: /tmp/anything
+`);
+      expect(() => reader.readManifest(manifestPath)).toThrow(
+        /flows\[0\]\.path '\/tmp\/anything' must be a relative path/,
+      );
+    });
+
+    it('rejects a flows[].path that escapes the manifest dir via ../', () => {
+      const manifestPath = writeManifest(`
+name: TestProject
+version: "1.0.0"
+flows:
+  - name: Escape
+    path: ../../../../etc/evil
+`);
+      expect(() => reader.readManifest(manifestPath)).toThrow(
+        /flows\[0\]\.path '\.\.\/\.\.\/\.\.\/\.\.\/etc\/evil' escapes the manifest directory/,
+      );
+    });
+  });
+
   describe('defaults', () => {
     it('applies default watch config when absent', () => {
       const manifestPath = writeManifest(`

--- a/packages/core/src/manifest/manifest-reader.ts
+++ b/packages/core/src/manifest/manifest-reader.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { isAbsolute, resolve, dirname, sep } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import type {
   ManifestConfiguration,
@@ -9,6 +9,37 @@ import type {
 } from '../ir/index.js';
 
 const ALLOWED_FORMATS = new Set(['typescript', 'gherkin', 'markdown'] as const);
+
+/**
+ * Reject a manifest-declared path that is absolute or escapes the manifest
+ * directory when resolved. Both constraints matter: the manifest is checked
+ * into the project, so any field that names a file/directory should stay
+ * inside the project root (which is the manifest's own directory).
+ *
+ * An unguarded outputDir like `/etc/` or `../../../outside` would cause any
+ * downstream writer (generate, emit-ts, simulate) to write outside the
+ * project. An unguarded file-ref path like `../../etc/passwd` would cause
+ * the parser to read and interpret an arbitrary file as a .moment spec.
+ *
+ * Uses a path-separator boundary check so `/base-sibling` can't masquerade
+ * as being inside `/base` — same shape as the guard in @mmmnt/cli's
+ * project-fs.ts, duplicated here because @mmmnt/core can't depend on cli.
+ */
+function assertPathWithinManifestDir(field: string, value: string, manifestDir: string): void {
+  if (isAbsolute(value)) {
+    throw new Error(
+      `Manifest validation failed: ${field} '${value}' must be a relative path (absolute paths are rejected).`,
+    );
+  }
+  const resolvedBase = resolve(manifestDir);
+  const resolvedTarget = resolve(resolvedBase, value);
+  const baseWithSep = resolvedBase.endsWith(sep) ? resolvedBase : resolvedBase + sep;
+  if (resolvedTarget !== resolvedBase && !resolvedTarget.startsWith(baseWithSep)) {
+    throw new Error(
+      `Manifest validation failed: ${field} '${value}' escapes the manifest directory (${manifestDir}).`,
+    );
+  }
+}
 
 export class ManifestReader {
   readManifest(manifestPath: string): ManifestConfiguration {
@@ -28,9 +59,9 @@ export class ManifestReader {
     const version = typeof obj.version === 'string' ? obj.version : '0.0.0';
     const description = typeof obj.description === 'string' ? obj.description : undefined;
 
-    const contexts = this.parseFileRefs(obj.contexts);
-    const flows = this.parseFileRefs(obj.flows);
-    const generators = this.parseGenerators(obj.generators);
+    const contexts = this.parseFileRefs(obj.contexts, 'contexts', manifestDir);
+    const flows = this.parseFileRefs(obj.flows, 'flows', manifestDir);
+    const generators = this.parseGenerators(obj.generators, manifestDir);
     const watch = this.parseWatch(obj.watch);
 
     this.validateFileRefs(manifestDir, contexts, flows);
@@ -38,7 +69,7 @@ export class ManifestReader {
     return { name, version, description, contexts, flows, generators, watch };
   }
 
-  private parseFileRefs(entries: unknown): FileRef[] {
+  private parseFileRefs(entries: unknown, fieldName: string, manifestDir: string): FileRef[] {
     if (entries == null) {
       return [];
     }
@@ -57,11 +88,16 @@ export class ManifestReader {
           `Manifest validation failed: file reference at index ${index} must have string 'name' and 'path'.`,
         );
       }
+      // Defense in depth: reject file refs that point outside the manifest
+      // directory. Without this guard, a malicious manifest could name a
+      // `.moment` spec at an absolute path or via `../` climbs, and the
+      // parser would happily read and interpret arbitrary files.
+      assertPathWithinManifestDir(`${fieldName}[${index}].path`, candidate.path, manifestDir);
       return { name: candidate.name, path: candidate.path };
     });
   }
 
-  private parseGenerators(entries: unknown): GeneratorConfig[] {
+  private parseGenerators(entries: unknown, manifestDir: string): GeneratorConfig[] {
     if (entries == null) {
       return [];
     }
@@ -88,9 +124,16 @@ export class ManifestReader {
           `Manifest validation failed: 'outputDir' for generator at index ${index} must be a string.`,
         );
       }
+      const outputDir = typeof candidate.outputDir === 'string' ? candidate.outputDir : '';
+      // Reject absolute paths and traversal escapes. An unguarded outputDir
+      // like `/etc/` or `../../../outside` would make any downstream writer
+      // (generate, emit-ts) write outside the project.
+      if (outputDir !== '') {
+        assertPathWithinManifestDir(`generators[${index}].outputDir`, outputDir, manifestDir);
+      }
       return {
         format: candidate.format as 'typescript' | 'gherkin' | 'markdown',
-        outputDir: typeof candidate.outputDir === 'string' ? candidate.outputDir : '',
+        outputDir,
       };
     });
   }


### PR DESCRIPTION
Closes **P2 #6** from the post-mortem. `ManifestReader` now validates that three manifest fields — `generators[].outputDir`, `contexts[].path`, and `flows[].path` — are relative paths that stay inside the manifest directory. Previously any of these could be absolute or use `../` to escape, and downstream tools would honor them.

**Threat model:**
- **Write attack**: A malicious `outputDir: /etc/evil` or `outputDir: ../../../outside` would make `moment generate` / `moment emit-ts` write files outside the project. Same class of path-traversal bug as the `simulate --out-dir` vuln fixed in #145, but entering through the manifest instead of the flow name.
- **Read attack**: A malicious `contexts[0].path: ../../../etc/passwd` would make the parser read and interpret an arbitrary file as a `.moment` spec.

**What changed:**
- New private `assertPathWithinManifestDir` in `manifest-reader.ts` — rejects absolute paths and checks a resolved `../` climb against the manifest dir with a path-separator boundary check. Same shape as the `assertPathWithin` in `@mmmnt/cli`'s `project-fs.ts`, duplicated because `@mmmnt/core` can't depend on `@mmmnt/cli`.
- Applied in `parseFileRefs` (contexts + flows) and `parseGenerators` (outputDir). Clear, field-specific error messages:
  ```
  Manifest validation failed: generators[0].outputDir '/etc/evil' must be a relative path (absolute paths are rejected).
  Manifest validation failed: contexts[0].path '../../../etc/passwd' escapes the manifest directory (/path/to/project).
  ```
- 8 new tests in `manifest-reader.spec.ts` covering: absolute + traversing `outputDir`, relative `outputDir` accepted, empty/missing `outputDir` back-compat, absolute + traversing `contexts[].path`, absolute + traversing `flows[].path`.
- Changeset: patch bump.

**Test plan:**
- [x] 300/300 `@mmmnt/core` tests pass (8 new)
- [x] 176/176 `@mmmnt/cli` tests pass (no regression from the new validation)
- [x] Lint clean
- [ ] CI passes on this PR

## Progress

| Item | Status |
|---|---|
| P2 #5 path-traversal simulate | ✅ (#145) |
| **P2 #6 ManifestReader** | **this PR** |
| P2 #7 README drift | next |
