### PR TITLE
fix: guard broken sync commands + workflow_dispatch + security overrides

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,13 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Checkout (head SHA from triggering CI run)
+      - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # workflow_run provides head_sha; workflow_dispatch uses the
+          # default branch HEAD (github.sha). The || fallback keeps
+          # both triggers working without a separate checkout step.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
           # Using the app token here means subsequent `git push` operations
           # (e.g. the auto-changeset step pushing back to main) authenticate
@@ -156,8 +159,9 @@ jobs:
           else
             git commit -m "chore: auto-changeset for ${HEAD_SHA} [skip ci]"
 
-            if git push origin "HEAD:${{ github.event.workflow_run.head_branch }}"; then
-              echo "Pushed auto-changeset back to ${{ github.event.workflow_run.head_branch }}."
+            TARGET_BRANCH="${{ github.event.workflow_run.head_branch || github.ref_name }}"
+            if git push origin "HEAD:${TARGET_BRANCH}"; then
+              echo "Pushed auto-changeset back to ${TARGET_BRANCH}."
             else
               echo "::warning::Could not push auto-changeset back to main (branch protection?). The changeset still exists in the working tree and will be consumed by changesets/action in this run."
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,11 @@ name: Release
 
 # Triggered automatically when CI completes on main. The release job only
 # runs when CI succeeded, so a broken merge cannot ship.
+# Also supports manual triggering via the Actions UI as a safety valve
+# when workflow_run doesn't fire (e.g. the chicken-and-egg gotcha after
+# a workflow file change, or to re-run a failed publish).
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: [CI]
     types: [completed]
@@ -19,7 +23,9 @@ permissions:
 
 jobs:
   release:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       # Generate a short-lived installation token for the mmmnt-release

--- a/package.json
+++ b/package.json
@@ -55,10 +55,9 @@
       "esbuild"
     ],
     "overrides": {
-      "hono": ">=4.12.12",
-      "@hono/node-server": ">=1.19.13",
-      "picomatch": ">=4.0.2",
-      "brace-expansion": ">=2.0.2"
+      "hono": ">=4.12.12 <5",
+      "@hono/node-server": ">=1.19.13 <2",
+      "picomatch": ">=4.0.2 <5"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,12 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ]
+    ],
+    "overrides": {
+      "hono": ">=4.12.12",
+      "@hono/node-server": ">=1.19.13",
+      "picomatch": ">=4.0.2",
+      "brace-expansion": ">=2.0.2"
+    }
   }
 }

--- a/packages/cli/src/commands/sync-accept.test.ts
+++ b/packages/cli/src/commands/sync-accept.test.ts
@@ -5,78 +5,42 @@ import { runSyncAccept } from './sync-accept.js';
 
 const FIXTURES = resolve(import.meta.dirname, '../../../../fixtures');
 const VALID_FIXTURE = resolve(FIXTURES, 'valid/minimal/contexts/ordering.moment');
-const UNIFIED_FIXTURE = resolve(FIXTURES, 'valid/unified/vet-clinic.moment');
-const INVALID_FIXTURE = resolve(FIXTURES, 'invalid/no-declaration.moment');
 
 describe('moment sync accept', () => {
-  it('--all accepts all pending proposals', async () => {
-    const result = await runSyncAccept(['--all', UNIFIED_FIXTURE]);
-
-    expect(result.success).toBe(true);
-    expect(result.acceptedCount).toBeGreaterThanOrEqual(0);
-    if (result.acceptedCount > 0) {
-      expect(result.message).toContain('Accepted');
-    }
-  });
-
-  it('invalid proposal ID exits with diagnostic when proposals exist', async () => {
-    const result = await runSyncAccept([UNIFIED_FIXTURE, 'nonexistent-id-12345']);
-
-    // If proposals exist, an invalid ID should fail
-    // If no proposals exist, it succeeds with "No pending proposals"
-    if (result.message.includes('No pending')) {
-      expect(result.success).toBe(true);
-    } else {
-      expect(result.success).toBe(false);
-      expect(result.message).toContain('Unknown proposal ID');
-    }
-  });
-
   it('no arguments returns usage message', async () => {
     const result = await runSyncAccept([]);
-
     expect(result.success).toBe(false);
     expect(result.message).toContain('Usage:');
   });
 
-  it('file path only without --all or IDs returns usage message', async () => {
-    const result = await runSyncAccept([VALID_FIXTURE]);
-
-    // With no --all and no proposal IDs, should fail with usage
-    // Unless there are no proposals (then "No pending proposals")
-    expect(result.success === false || result.message.includes('No pending')).toBe(true);
-  });
-
-  it('--json returns valid JSON', async () => {
-    const result = await runSyncAccept(['--json', '--all', UNIFIED_FIXTURE]);
-
-    expect(result.success).toBe(true);
-    if (result.json) {
-      const parsed = JSON.parse(result.json);
-      expect(typeof parsed.accepted).toBe('number');
-    }
-  });
-
-  it('invalid spec returns failure with parse diagnostics', async () => {
-    const result = await runSyncAccept(['--all', INVALID_FIXTURE]);
-
+  it('returns "not yet fully implemented" for any file argument', async () => {
+    const result = await runSyncAccept(['--all', VALID_FIXTURE]);
     expect(result.success).toBe(false);
-    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.message).toContain('not yet fully implemented');
+    expect(result.message).toContain('not persisted');
   });
 
-  it('nonexistent path returns failure with file-not-found', async () => {
-    const nonexistent = join(tmpdir(), 'nonexistent-accept-12345.moment');
-    const result = await runSyncAccept(['--all', nonexistent]);
-
+  it('returns "not yet fully implemented" for specific proposal IDs', async () => {
+    const result = await runSyncAccept([VALID_FIXTURE, 'prop-001']);
     expect(result.success).toBe(false);
-    expect(result.message).toContain('File not found');
+    expect(result.message).toContain('not yet fully implemented');
   });
 
-  it('delegates to SyncState.acceptProposal — no state logic in CLI', async () => {
-    // EXIT-C1: The command delegates; verify it returns structured results
-    const result = await runSyncAccept(['--all', UNIFIED_FIXTURE]);
-    expect(result.success).toBe(true);
-    expect(typeof result.acceptedCount).toBe('number');
-    expect(result.diagnostics).toHaveLength(0);
+  it('returns "not yet fully implemented" even for nonexistent paths', async () => {
+    // The guard fires after the file-path check but before parse. A
+    // nonexistent path hits the "file not found" branch first — that's
+    // fine, it's a cheaper error that makes more sense to the user.
+    const nonexistent = join(tmpdir(), 'nonexistent-sync-accept-12345.moment');
+    const result = await runSyncAccept([nonexistent]);
+    expect(result.success).toBe(false);
+    // Either "File not found" (existing check) or "not yet fully
+    // implemented" (guard) — both are correct failures.
+    expect(result.message).toMatch(/File not found|not yet fully implemented/);
+  });
+
+  it('returns "not yet fully implemented" with --json', async () => {
+    const result = await runSyncAccept(['--all', '--json', VALID_FIXTURE]);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('not yet fully implemented');
   });
 });

--- a/packages/cli/src/commands/sync-accept.ts
+++ b/packages/cli/src/commands/sync-accept.ts
@@ -4,14 +4,8 @@
  * Delegates to SyncState.acceptProposal() — no state logic in CLI (EXIT-C1).
  */
 
-import { readFileSync, existsSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
 import { parseArgs } from 'node:util';
-import { MomentParser } from '@mmmnt/core';
-import { TypeScriptEmitter } from '@mmmnt/emit-ts';
-import { ASTDiffEngine, LocalGitArtifactStore, SyncState } from '@mmmnt/sync';
-import type { Diagnostic, IntermediateRepresentation } from '@mmmnt/core';
-import type { ImplementationChangeProposal } from '@mmmnt/sync';
+import type { Diagnostic } from '@mmmnt/core';
 
 export interface SyncAcceptResult {
   readonly success: boolean;
@@ -52,158 +46,21 @@ export async function runSyncAccept(argv: string[]): Promise<SyncAcceptResult> {
   const filePath = positionals[0];
   if (!filePath) return fail(USAGE);
 
-  const parsed = await parseSpecFile(filePath);
-  if (!('ir' in parsed)) return parsed;
-
-  const { ir, resolvedPath } = parsed;
-  const proposals = await generateProposals(ir, resolvedPath);
-
-  if (proposals.length === 0) {
-    return {
-      success: true,
-      message: 'No pending proposals to accept',
-      diagnostics: EMPTY,
-      acceptedCount: 0,
-    };
-  }
-
-  return executeAccept(proposals, values.all === true, positionals.slice(1), values.json === true);
-}
-
-function executeAccept(
-  proposals: ImplementationChangeProposal[],
-  acceptAll: boolean,
-  proposalIds: string[],
-  asJson: boolean,
-): SyncAcceptResult {
-  // GUARD: sync accept is not yet fully implemented. The SyncState aggregate
-  // below records and "accepts" proposals in memory, but:
-  //   1. The acceptance is never persisted to .domain/sync-state.jsonl
-  //   2. The proposed changes are never applied to the actual TypeScript files
-  // So the command would report "Accepted N proposal(s)" while doing nothing
-  // on disk — a silent no-op that misleads users. Fail loudly until both
-  // persistence and application are implemented. See the post-mortem P1 #3
-  // analysis for the full breakdown.
+  // GUARD: sync accept is not yet fully implemented. SyncState records and
+  // "accepts" proposals in memory, but (1) the acceptance is never persisted
+  // to .domain/sync-state.jsonl and (2) the proposed changes are never
+  // applied to the actual TypeScript files. Fail fast before doing any
+  // expensive parse/emit/diff work.
   return fail(
     'Error: sync accept is not yet fully implemented — accepted proposals are not ' +
       'persisted and not applied to files. Use `moment sync propose` to generate ' +
       'proposals, then apply them manually. ' +
       'See https://github.com/mmmnt/mmmnt/issues for tracking.',
   );
-
-  const syncState = new SyncState();
-  for (const p of proposals) {
-    syncState.recordProposal(p);
-  }
-
-  if (!acceptAll && proposalIds.length === 0) {
-    return fail(USAGE);
-  }
-
-  const result = acceptAll
-    ? acceptAllProposals(
-        syncState,
-        proposals.map((p) => p.proposalId),
-      )
-    : acceptByIds(
-        syncState,
-        proposalIds,
-        proposals.map((p) => p.proposalId),
-      );
-
-  if (!result.success || !asJson) return result;
-
-  const json = JSON.stringify({ accepted: result.acceptedCount }, null, 2);
-  return { ...result, message: json, json };
 }
 
-async function parseSpecFile(
-  filePath: string,
-): Promise<SyncAcceptResult | { ir: IntermediateRepresentation; resolvedPath: string }> {
-  const resolvedPath = resolve(filePath);
-  if (!existsSync(resolvedPath)) return fail(`Error: File not found: ${resolvedPath}`);
-
-  const content = readFile(resolvedPath);
-  if (typeof content !== 'string') return content;
-
-  const parseResult = await new MomentParser().parseContent(content);
-
-  if (!parseResult.success) {
-    return {
-      success: false,
-      message: `Parse failed with ${parseResult.diagnostics.length} diagnostic(s)`,
-      diagnostics: parseResult.diagnostics,
-      filePath: resolvedPath,
-      acceptedCount: 0,
-    };
-  }
-
-  return { ir: parseResult.ir!, resolvedPath };
-}
-
-async function generateProposals(
-  ir: IntermediateRepresentation,
-  resolvedPath: string,
-): Promise<ImplementationChangeProposal[]> {
-  const tsOutput = new TypeScriptEmitter().emit(ir, { scope: { level: 'system' } });
-  const repoRoot = dirname(resolvedPath);
-  const store = new LocalGitArtifactStore(repoRoot);
-  const actual = await readActualFiles(store, [...tsOutput.files.keys()]);
-
-  return new ASTDiffEngine().generateProposals({ expected: tsOutput.files, actual });
-}
-
-function acceptAllProposals(syncState: SyncState, allIds: string[]): SyncAcceptResult {
-  for (const id of allIds) {
-    syncState.acceptProposal(id);
-  }
-  return {
-    success: true,
-    message: `Accepted ${allIds.length} proposal(s)`,
-    diagnostics: EMPTY,
-    acceptedCount: allIds.length,
-  };
-}
-
-function acceptByIds(
-  syncState: SyncState,
-  requestedIds: string[],
-  validIds: string[],
-): SyncAcceptResult {
-  const uniqueIds = [...new Set(requestedIds)];
-  const validSet = new Set(validIds);
-  const invalid = uniqueIds.filter((id) => !validSet.has(id));
-
-  if (invalid.length > 0) {
-    return fail(`Error: Unknown proposal ID(s): ${invalid.join(', ')}`);
-  }
-
-  for (const id of uniqueIds) {
-    syncState.acceptProposal(id);
-  }
-
-  return {
-    success: true,
-    message: `Accepted ${uniqueIds.length} proposal(s)`,
-    diagnostics: EMPTY,
-    acceptedCount: uniqueIds.length,
-  };
-}
-
-async function readActualFiles(
-  store: LocalGitArtifactStore,
-  paths: string[],
-): Promise<Map<string, string>> {
-  const actual = new Map<string, string>();
-  for (const path of paths) {
-    try {
-      const content = await store.readArtifact(path);
-      actual.set(path, content);
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : '';
-      if (msg.startsWith('Artifact not found')) continue;
-      throw err;
-    }
-  }
-  return actual;
-}
+// parseSpecFile, generateProposals, executeAccept, acceptAllProposals,
+// acceptByIds, and readActualFiles were all removed because they are
+// unreachable below the fail() guard above. They'll be restored (with
+// real persistence + disk writes) when the full sync-accept pipeline
+// is implemented.

--- a/packages/cli/src/commands/sync-accept.ts
+++ b/packages/cli/src/commands/sync-accept.ts
@@ -9,11 +9,7 @@ import { resolve, dirname } from 'node:path';
 import { parseArgs } from 'node:util';
 import { MomentParser } from '@mmmnt/core';
 import { TypeScriptEmitter } from '@mmmnt/emit-ts';
-import {
-  ASTDiffEngine,
-  LocalGitArtifactStore,
-  SyncState,
-} from '@mmmnt/sync';
+import { ASTDiffEngine, LocalGitArtifactStore, SyncState } from '@mmmnt/sync';
 import type { Diagnostic, IntermediateRepresentation } from '@mmmnt/core';
 import type { ImplementationChangeProposal } from '@mmmnt/sync';
 
@@ -63,7 +59,12 @@ export async function runSyncAccept(argv: string[]): Promise<SyncAcceptResult> {
   const proposals = await generateProposals(ir, resolvedPath);
 
   if (proposals.length === 0) {
-    return { success: true, message: 'No pending proposals to accept', diagnostics: EMPTY, acceptedCount: 0 };
+    return {
+      success: true,
+      message: 'No pending proposals to accept',
+      diagnostics: EMPTY,
+      acceptedCount: 0,
+    };
   }
 
   return executeAccept(proposals, values.all === true, positionals.slice(1), values.json === true);
@@ -75,6 +76,21 @@ function executeAccept(
   proposalIds: string[],
   asJson: boolean,
 ): SyncAcceptResult {
+  // GUARD: sync accept is not yet fully implemented. The SyncState aggregate
+  // below records and "accepts" proposals in memory, but:
+  //   1. The acceptance is never persisted to .domain/sync-state.jsonl
+  //   2. The proposed changes are never applied to the actual TypeScript files
+  // So the command would report "Accepted N proposal(s)" while doing nothing
+  // on disk — a silent no-op that misleads users. Fail loudly until both
+  // persistence and application are implemented. See the post-mortem P1 #3
+  // analysis for the full breakdown.
+  return fail(
+    'Error: sync accept is not yet fully implemented — accepted proposals are not ' +
+      'persisted and not applied to files. Use `moment sync propose` to generate ' +
+      'proposals, then apply them manually. ' +
+      'See https://github.com/mmmnt/mmmnt/issues for tracking.',
+  );
+
   const syncState = new SyncState();
   for (const p of proposals) {
     syncState.recordProposal(p);
@@ -85,8 +101,15 @@ function executeAccept(
   }
 
   const result = acceptAll
-    ? acceptAllProposals(syncState, proposals.map((p) => p.proposalId))
-    : acceptByIds(syncState, proposalIds, proposals.map((p) => p.proposalId));
+    ? acceptAllProposals(
+        syncState,
+        proposals.map((p) => p.proposalId),
+      )
+    : acceptByIds(
+        syncState,
+        proposalIds,
+        proposals.map((p) => p.proposalId),
+      );
 
   if (!result.success || !asJson) return result;
 
@@ -94,7 +117,9 @@ function executeAccept(
   return { ...result, message: json, json };
 }
 
-async function parseSpecFile(filePath: string): Promise<SyncAcceptResult | { ir: IntermediateRepresentation; resolvedPath: string }> {
+async function parseSpecFile(
+  filePath: string,
+): Promise<SyncAcceptResult | { ir: IntermediateRepresentation; resolvedPath: string }> {
   const resolvedPath = resolve(filePath);
   if (!existsSync(resolvedPath)) return fail(`Error: File not found: ${resolvedPath}`);
 
@@ -116,7 +141,10 @@ async function parseSpecFile(filePath: string): Promise<SyncAcceptResult | { ir:
   return { ir: parseResult.ir!, resolvedPath };
 }
 
-async function generateProposals(ir: IntermediateRepresentation, resolvedPath: string): Promise<ImplementationChangeProposal[]> {
+async function generateProposals(
+  ir: IntermediateRepresentation,
+  resolvedPath: string,
+): Promise<ImplementationChangeProposal[]> {
   const tsOutput = new TypeScriptEmitter().emit(ir, { scope: { level: 'system' } });
   const repoRoot = dirname(resolvedPath);
   const store = new LocalGitArtifactStore(repoRoot);
@@ -125,10 +153,7 @@ async function generateProposals(ir: IntermediateRepresentation, resolvedPath: s
   return new ASTDiffEngine().generateProposals({ expected: tsOutput.files, actual });
 }
 
-function acceptAllProposals(
-  syncState: SyncState,
-  allIds: string[],
-): SyncAcceptResult {
+function acceptAllProposals(syncState: SyncState, allIds: string[]): SyncAcceptResult {
   for (const id of allIds) {
     syncState.acceptProposal(id);
   }

--- a/packages/cli/src/commands/sync-propose.test.ts
+++ b/packages/cli/src/commands/sync-propose.test.ts
@@ -26,15 +26,15 @@ describe('moment sync propose', () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it('--auto-accept accepts all proposals without interaction', async () => {
+  it('--auto-accept returns "not yet fully implemented" error', async () => {
+    // --auto-accept is guarded because it has the same "silent no-op" bug
+    // as sync accept — SyncState accepts in memory but never persists or
+    // applies to disk. The guard fires before any pipeline work.
     const result = await runSyncPropose(['--auto-accept', VALID_FIXTURE]);
 
-    expect(result.success).toBe(true);
-    if (result.proposals && result.proposals.length > 0) {
-      expect(result.accepted).toBe(result.proposals.length);
-      expect(result.rejected).toBe(0);
-      expect(result.skipped).toBe(0);
-    }
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('not yet fully implemented');
+    expect(result.message).toContain('not persisted');
   });
 
   it('without --auto-accept skips all proposals', async () => {

--- a/packages/cli/src/commands/sync-propose.ts
+++ b/packages/cli/src/commands/sync-propose.ts
@@ -11,12 +11,7 @@ import { resolve, dirname } from 'node:path';
 import { parseArgs } from 'node:util';
 import { MomentParser } from '@mmmnt/core';
 import { TypeScriptEmitter } from '@mmmnt/emit-ts';
-import {
-  ASTDiffEngine,
-  LocalGitArtifactStore,
-  PushFlowSaga,
-  SyncState,
-} from '@mmmnt/sync';
+import { ASTDiffEngine, LocalGitArtifactStore, PushFlowSaga, SyncState } from '@mmmnt/sync';
 import type { Diagnostic } from '@mmmnt/core';
 import type { ImplementationChangeProposal } from '@mmmnt/sync';
 
@@ -125,6 +120,20 @@ export async function runSyncPropose(argv: string[]): Promise<SyncProposeResult>
 
   // Auto-accept mode or skip (non-interactive CLI defaults to skip)
   const autoAccept = values['auto-accept'] === true;
+
+  // GUARD: --auto-accept has the same "silent no-op" bug as sync accept.
+  // SyncState.acceptProposal() runs in memory but is never persisted and
+  // the proposals are never applied to files on disk. Fail loudly until
+  // the full persistence + application pipeline is implemented.
+  if (autoAccept) {
+    return fail(
+      'Error: --auto-accept is not yet fully implemented — accepted proposals are not ' +
+        'persisted and not applied to files. Omit --auto-accept to generate proposals ' +
+        'for manual review instead. ' +
+        'See https://github.com/mmmnt/mmmnt/issues for tracking.',
+    );
+  }
+
   const counts = processProposals(proposals, syncState, autoAccept);
 
   // Drive saga to terminal state
@@ -207,6 +216,8 @@ function formatProposalSummary(
   }
 
   lines.push('');
-  lines.push(`Accepted: ${counts.accepted}, Rejected: ${counts.rejected}, Skipped: ${counts.skipped}`);
+  lines.push(
+    `Accepted: ${counts.accepted}, Rejected: ${counts.rejected}, Skipped: ${counts.skipped}`,
+  );
   return lines.join('\n');
 }

--- a/packages/cli/src/commands/sync-propose.ts
+++ b/packages/cli/src/commands/sync-propose.ts
@@ -53,6 +53,19 @@ export async function runSyncPropose(argv: string[]): Promise<SyncProposeResult>
     strict: false,
   });
 
+  // Fail fast for --auto-accept before doing any expensive work (parse,
+  // emit, diff). The guard is here rather than after the pipeline because
+  // auto-accept has the same "silent no-op" bug as sync accept — SyncState
+  // accepts in memory but never persists or applies to files on disk.
+  if (values['auto-accept'] === true) {
+    return fail(
+      'Error: --auto-accept is not yet fully implemented — accepted proposals are not ' +
+        'persisted and not applied to files. Omit --auto-accept to generate proposals ' +
+        'for manual review instead. ' +
+        'See https://github.com/mmmnt/mmmnt/issues for tracking.',
+    );
+  }
+
   const filePath = positionals[0];
   if (!filePath) return fail('Usage: moment sync propose <file.moment>');
 
@@ -118,22 +131,11 @@ export async function runSyncPropose(argv: string[]): Promise<SyncProposeResult>
     syncState.recordProposal(p);
   }
 
-  // Auto-accept mode or skip (non-interactive CLI defaults to skip)
-  const autoAccept = values['auto-accept'] === true;
-
-  // GUARD: --auto-accept has the same "silent no-op" bug as sync accept.
-  // SyncState.acceptProposal() runs in memory but is never persisted and
-  // the proposals are never applied to files on disk. Fail loudly until
-  // the full persistence + application pipeline is implemented.
-  if (autoAccept) {
-    return fail(
-      'Error: --auto-accept is not yet fully implemented — accepted proposals are not ' +
-        'persisted and not applied to files. Omit --auto-accept to generate proposals ' +
-        'for manual review instead. ' +
-        'See https://github.com/mmmnt/mmmnt/issues for tracking.',
-    );
-  }
-
+  // autoAccept is always false here — the guard at the top of runSyncPropose
+  // rejects --auto-accept before we reach this point. Kept as a local for
+  // API compatibility with processProposals until the real implementation
+  // lands.
+  const autoAccept = false;
   const counts = processProposals(proposals, syncState, autoAccept);
 
   // Drive saga to terminal state

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,6 @@ overrides:
   hono: '>=4.12.12'
   '@hono/node-server': '>=1.19.13'
   picomatch: '>=4.0.2'
-  brace-expansion: '>=2.0.2'
 
 importers:
   .:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  hono: '>=4.12.12'
+  '@hono/node-server': '>=1.19.13'
+  picomatch: '>=4.0.2'
+  brace-expansion: '>=2.0.2'
+
 importers:
   .:
     devDependencies:
@@ -219,7 +225,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       picomatch:
-        specifier: ^4.0.4
+        specifier: '>=4.0.2'
         version: 4.0.4
     devDependencies:
       '@types/picomatch':
@@ -1575,14 +1581,14 @@ packages:
         integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==,
       }
 
-  '@hono/node-server@1.19.12':
+  '@hono/node-server@1.19.13':
     resolution:
       {
-        integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==,
+        integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==,
       }
     engines: { node: '>=18.14.1' }
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.12'
 
   '@humanfs/core@0.19.1':
     resolution:
@@ -4091,7 +4097,7 @@ packages:
       }
     engines: { node: '>=12.0.0' }
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.2'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -4432,10 +4438,10 @@ packages:
       }
     hasBin: true
 
-  hono@4.12.10:
+  hono@4.12.12:
     resolution:
       {
-        integrity: sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==,
+        integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==,
       }
     engines: { node: '>=16.9.0' }
 
@@ -5789,20 +5795,6 @@ packages:
       {
         integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
       }
-
-  picomatch@2.3.2:
-    resolution:
-      {
-        integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
-      }
-    engines: { node: '>=8.6' }
-
-  picomatch@4.0.3:
-    resolution:
-      {
-        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
-      }
-    engines: { node: '>=12' }
 
   picomatch@4.0.4:
     resolution:
@@ -8140,9 +8132,9 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@1.19.12(hono@4.12.10)':
+  '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
-      hono: 4.12.10
+      hono: 4.12.12
 
   '@humanfs/core@0.19.1': {}
 
@@ -8307,7 +8299,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.12(hono@4.12.10)
+      '@hono/node-server': 1.19.13(hono@4.12.12)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -8317,7 +8309,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.10
+      hono: 4.12.12
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -8424,7 +8416,7 @@ snapshots:
   '@rollup/pluginutils@4.2.1':
     dependencies:
       estree-walker: 2.0.2
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
     dependencies:
@@ -8925,7 +8917,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   arg@5.0.2: {}
 
@@ -9963,7 +9955,7 @@ snapshots:
 
   he@1.2.0: {}
 
-  hono@4.12.10: {}
+  hono@4.12.12: {}
 
   html-escaper@2.0.2: {}
 
@@ -10194,7 +10186,7 @@ snapshots:
     dependencies:
       commander: 14.0.3
       listr2: 9.0.5
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       string-argv: 0.3.2
       tinyexec: 1.0.4
       yaml: 2.8.3
@@ -10615,7 +10607,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   mime-db@1.54.0: {}
 
@@ -10818,10 +10810,6 @@ snapshots:
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
-
-  picomatch@2.3.2: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: '>=4.12.12'
-  '@hono/node-server': '>=1.19.13'
-  picomatch: '>=4.0.2'
+  hono: '>=4.12.12 <5'
+  '@hono/node-server': '>=1.19.13 <2'
+  picomatch: '>=4.0.2 <5'
 
 importers:
   .:
@@ -224,7 +224,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       picomatch:
-        specifier: '>=4.0.2'
+        specifier: '>=4.0.2 <5'
         version: 4.0.4
     devDependencies:
       '@types/picomatch':
@@ -1587,7 +1587,7 @@ packages:
       }
     engines: { node: '>=18.14.1' }
     peerDependencies:
-      hono: '>=4.12.12'
+      hono: '>=4.12.12 <5'
 
   '@humanfs/core@0.19.1':
     resolution:
@@ -4096,7 +4096,7 @@ packages:
       }
     engines: { node: '>=12.0.0' }
     peerDependencies:
-      picomatch: '>=4.0.2'
+      picomatch: '>=4.0.2 <5'
     peerDependenciesMeta:
       picomatch:
         optional: true


### PR DESCRIPTION
Closes **P1 #3** (Option A — guard PR), **P3 #8** (workflow_dispatch safety valve), and **P3 #9** (Dependabot vulns triage + partial fix).

## Three changes in one PR

### 1. Guard broken sync accept / sync propose --auto-accept (P1 #3 Option A)

`moment sync accept` and `moment sync propose --auto-accept` are silent no-ops that claim success while writing nothing to disk. `SyncState` records and accepts proposals in memory but never persists to `.domain/sync-state.jsonl` and never applies the proposed changes to actual TypeScript files.

Rather than let consumers rely on commands that pretend to work, both now **fail fast with clear messages**:

```
$ moment sync accept spec.moment --all
Error: sync accept is not yet fully implemented — accepted proposals
are not persisted and not applied to files.

$ moment sync propose --auto-accept spec.moment
Error: --auto-accept is not yet fully implemented — accepted proposals
are not persisted and not applied to files.
```

The non-auto-accept path of `sync propose` (generating proposals for manual review) is unaffected.

### 2. Add `workflow_dispatch` to release.yml (P3 #8)

Safety valve so the release workflow can be fired manually from the Actions UI when `workflow_run` doesn't trigger (the chicken-and-egg gotcha we hit after #137). The release job's `if:` condition now accepts both `workflow_dispatch` and `workflow_run` with `conclusion == 'success'`.

### 3. pnpm overrides for 8 transitive security vulnerabilities (P3 #9)

Triaged all 17 Dependabot-flagged vulns. All are in transitive dependencies, not direct code. pnpm overrides resolve 8:

| Override | Fixes | Via |
|---|---|---|
| `hono >= 4.12.12` | 5 moderate (cookie validation, IP matching, middleware bypass) | `@modelcontextprotocol/sdk` |
| `@hono/node-server >= 1.19.13` | 1 moderate (middleware bypass) | same |
| `picomatch >= 4.0.2` | 1 high (ReDoS) + 1 moderate (method injection) | `lint-staged` |

**17 → 9 remaining.** The 9 are upstream-blocked:

| Package | Severity | Blocked on |
|---|---|---|
| `lodash-es` | 2 high + 2 moderate | langium → chevrotain pins lodash. **Only consumer-facing vuln.** Needs langium to update chevrotain. |
| `vite` | 2 high + 1 moderate | vitest 3.x bundles old vite. Fix requires vitest 4.x major bump (separate PR). |
| `brace-expansion` | 2 moderate | `@vitest/coverage-v8` + `@typescript-eslint` pin older versions. Dev-only. |

## Test plan

- [x] 176/176 CLI tests pass
- [x] 300/300 core tests pass
- [x] `pnpm audit` confirms 17 → 9
- [ ] CI passes on this PR

## The full post-mortem list is now complete

```
P0  ✅ #139  serve <facet-dir>
P1  ✅ #143  runtime-deps audit CI gate
    ✅ this  sync accept/propose guard (Option A)
    ✅ #144  pack-and-install smoke test CI gate
P2  ✅ #145  path-traversal on simulate --out-dir
    ✅ #146  ManifestReader path validation
    ✅ #147  README drift sweep
P3  ✅ this  workflow_dispatch safety valve
    ✅ this  Dependabot triage (8/17 resolved, 9 upstream-blocked)
P4  ⏳ #10  manifest-driven project mode (0.4.0, separate session)
```
