### PR TITLE
feat(core): project loader for multi-file IR merge and cross-file validation

### DIFF
--- a/.changeset/project-loader.md
+++ b/.changeset/project-loader.md
@@ -1,0 +1,39 @@
+---
+'@mmmnt/core': minor
+---
+
+**feat(core): ProjectLoader for multi-file IR merge + cross-file validation**
+
+New `ProjectLoader` class in `@mmmnt/core` that loads multiple `.moment`
+files and produces a single merged `IntermediateRepresentation`. This is
+the Phase 1 foundation for project-level execution (MMNT-5418 / ADR-032 R2).
+
+Three new modules in `packages/core/src/project/`:
+
+- **`ProjectLoader`**: reads N files, parses each via `MomentParser`,
+  merges IRs, runs cross-file validation, returns a `ProjectLoadResult`
+  with the merged IR + aggregated diagnostics.
+- **`mergeIrs`**: pure function that concatenates `contexts[]`, `flows[]`,
+  `glossary[]`, `relationships[]` from N IRs with deterministic ordering
+  (sorted by file path). Detects duplicate context names across files.
+- **`validateCrossFileReferences`**: post-merge validator that checks lane
+  contextIds, crossing targetContextIds, moment entry contextIds, and
+  relationship endpoints all resolve to contexts in the merged IR. Skips
+  branch-lanes and terminal-classified lanes (synthetic flow-control
+  constructs, not real bounded contexts).
+
+```typescript
+import { ProjectLoader } from '@mmmnt/core';
+
+const loader = new ProjectLoader();
+const result = await loader.loadProject([
+  'contexts/ordering.moment',
+  'contexts/fulfillment.moment',
+  'flows/order-placed.moment',
+]);
+
+if (result.success) {
+  console.log(result.ir.contexts.length); // 2
+  console.log(result.ir.flows.length);    // 1
+}
+```

--- a/packages/core/__tests__/project/cross-file-validator.spec.ts
+++ b/packages/core/__tests__/project/cross-file-validator.spec.ts
@@ -107,8 +107,8 @@ describe('validateCrossFileReferences', () => {
   it('passes when relationship endpoints exist', () => {
     const ir = makeIr({
       contexts: [
-        { id: 'ctx-A', name: 'A', aggregates: [] } as any,
-        { id: 'ctx-B', name: 'B', aggregates: [] } as any,
+        { id: 'ctx-A', name: 'A', aggregates: [], events: [] } as any,
+        { id: 'ctx-B', name: 'B', aggregates: [], events: [] } as any,
       ],
       relationships: [
         {
@@ -156,6 +156,7 @@ describe('validateCrossFileReferences', () => {
           id: 'ctx-Target',
           name: 'Target',
           aggregates: [{ events: [{ name: 'ExistingEvent' }] }],
+          events: [{ name: 'ExistingEvent' }],
         } as any,
       ],
       flows: [

--- a/packages/core/__tests__/project/cross-file-validator.spec.ts
+++ b/packages/core/__tests__/project/cross-file-validator.spec.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import { validateCrossFileReferences } from '../../src/project/index.js';
+import type { IntermediateRepresentation } from '../../src/ir/index.js';
+
+function makeIr(overrides: Partial<IntermediateRepresentation> = {}): IntermediateRepresentation {
+  return {
+    contexts: [],
+    flows: [],
+    glossary: [],
+    relationships: [],
+    metadata: { name: 'test', version: '1.0.0' },
+    ...overrides,
+  };
+}
+
+describe('validateCrossFileReferences', () => {
+  it('passes for an empty IR', () => {
+    const result = validateCrossFileReferences(makeIr());
+    expect(result.valid).toBe(true);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('passes when all lane contextIds exist', () => {
+    const ir = makeIr({
+      contexts: [
+        {
+          id: 'ctx-Ordering',
+          name: 'Ordering',
+          aggregates: [],
+          commands: [],
+          events: [],
+          valueObjects: [],
+          invariants: [],
+          policies: [],
+          sagas: [],
+          domainServices: [],
+        } as any,
+      ],
+      flows: [
+        {
+          id: 'flow-test',
+          name: 'test',
+          lanes: [
+            { id: 'ordering', label: 'Ordering', contextId: 'ctx-Ordering', isBranch: false },
+          ],
+          moments: [],
+          connections: [],
+        } as any,
+      ],
+    });
+    const result = validateCrossFileReferences(ir);
+    expect(result.valid).toBe(true);
+  });
+
+  it('flags unresolved lane contextIds (PM-02)', () => {
+    const ir = makeIr({
+      flows: [
+        {
+          id: 'flow-test',
+          name: 'test',
+          lanes: [{ id: 'unknown', label: 'Unknown', contextId: 'ctx-Unknown', isBranch: false }],
+          moments: [],
+          connections: [],
+        } as any,
+      ],
+    });
+    const result = validateCrossFileReferences(ir);
+    expect(result.valid).toBe(false);
+    expect(result.diagnostics[0].ruleId).toBe('PM-02');
+  });
+
+  it('skips branch-lanes for PM-02', () => {
+    const ir = makeIr({
+      flows: [
+        {
+          id: 'flow-test',
+          name: 'test',
+          lanes: [
+            { id: 'branch', label: 'BranchLane', contextId: 'ctx-BranchLane', isBranch: true },
+          ],
+          moments: [],
+          connections: [],
+        } as any,
+      ],
+    });
+    const result = validateCrossFileReferences(ir);
+    expect(result.valid).toBe(true);
+  });
+
+  it('flags unresolved relationship endpoints (PM-06)', () => {
+    const ir = makeIr({
+      relationships: [
+        {
+          sourceContextId: 'ctx-Missing',
+          targetContextId: 'ctx-AlsoMissing',
+          relationshipType: 'CS',
+          contract: '',
+        },
+      ],
+    });
+    const result = validateCrossFileReferences(ir);
+    expect(result.valid).toBe(false);
+    const pm06 = result.diagnostics.filter((d) => d.ruleId === 'PM-06');
+    expect(pm06).toHaveLength(2); // both source and target missing
+  });
+
+  it('passes when relationship endpoints exist', () => {
+    const ir = makeIr({
+      contexts: [
+        { id: 'ctx-A', name: 'A', aggregates: [] } as any,
+        { id: 'ctx-B', name: 'B', aggregates: [] } as any,
+      ],
+      relationships: [
+        {
+          sourceContextId: 'ctx-A',
+          targetContextId: 'ctx-B',
+          relationshipType: 'CS',
+          contract: '',
+        },
+      ],
+    });
+    const result = validateCrossFileReferences(ir);
+    expect(result.valid).toBe(true);
+  });
+
+  it('flags unresolved crossing targetContextId (PM-03)', () => {
+    const ir = makeIr({
+      flows: [
+        {
+          id: 'flow-test',
+          name: 'test',
+          lanes: [],
+          moments: [],
+          connections: [
+            {
+              id: 'conn-1',
+              sourceMomentId: 'm-1',
+              targetContextId: 'ctx-Missing',
+              eventId: 'evt-X',
+              connectionType: 'crosses-to',
+              schemaContract: { eventType: 'X', fields: [], relationshipType: 'CS' },
+            },
+          ],
+        } as any,
+      ],
+    });
+    const result = validateCrossFileReferences(ir);
+    expect(result.valid).toBe(false);
+    expect(result.diagnostics[0].ruleId).toBe('PM-03');
+  });
+
+  it('warns when crossing event is not in target context (PM-04)', () => {
+    const ir = makeIr({
+      contexts: [
+        {
+          id: 'ctx-Target',
+          name: 'Target',
+          aggregates: [{ events: [{ name: 'ExistingEvent' }] }],
+        } as any,
+      ],
+      flows: [
+        {
+          id: 'flow-test',
+          name: 'test',
+          lanes: [],
+          moments: [],
+          connections: [
+            {
+              id: 'conn-1',
+              sourceMomentId: 'm-1',
+              targetContextId: 'ctx-Target',
+              eventId: 'evt-NonExistent',
+              connectionType: 'crosses-to',
+              schemaContract: { eventType: 'NonExistent', fields: [], relationshipType: 'CS' },
+            },
+          ],
+        } as any,
+      ],
+    });
+    const result = validateCrossFileReferences(ir);
+    // PM-04 is a warning, not an error — valid should still be true
+    expect(result.valid).toBe(true);
+    expect(result.diagnostics[0].ruleId).toBe('PM-04');
+    expect(result.diagnostics[0].severity).toBe('warning');
+  });
+
+  it('flags unresolved moment entry contextIds (PM-05)', () => {
+    const ir = makeIr({
+      flows: [
+        {
+          id: 'flow-test',
+          name: 'test',
+          lanes: [{ id: 'x', label: 'X', contextId: 'ctx-X', isBranch: false }],
+          moments: [
+            {
+              id: 'm-1',
+              name: 'Moment 1',
+              contextEntries: [{ contextId: 'ctx-Missing', nodeName: 'Cmd', nodeKind: 'command' }],
+            },
+          ],
+          connections: [],
+        } as any,
+      ],
+    });
+    const result = validateCrossFileReferences(ir);
+    expect(result.valid).toBe(false);
+    expect(result.diagnostics.some((d) => d.ruleId === 'PM-05')).toBe(true);
+  });
+});

--- a/packages/core/__tests__/project/ir-merger.spec.ts
+++ b/packages/core/__tests__/project/ir-merger.spec.ts
@@ -82,6 +82,7 @@ describe('mergeIrs', () => {
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].ruleId).toBe('PM-01');
     expect(result.diagnostics[0].message).toContain('Duplicate context name');
+    expect(result.diagnostics[0].message).toContain('IR #');
   });
 
   it('uses first IR metadata when no override', () => {

--- a/packages/core/__tests__/project/ir-merger.spec.ts
+++ b/packages/core/__tests__/project/ir-merger.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { mergeIrs } from '../../src/project/index.js';
+import type { IntermediateRepresentation } from '../../src/ir/index.js';
+
+function emptyIr(name = 'test'): IntermediateRepresentation {
+  return {
+    contexts: [],
+    flows: [],
+    glossary: [],
+    relationships: [],
+    metadata: { name, version: '1.0.0' },
+  };
+}
+
+describe('mergeIrs', () => {
+  it('returns empty IR for empty input', () => {
+    const result = mergeIrs([]);
+    expect(result.ir.contexts).toHaveLength(0);
+    expect(result.ir.flows).toHaveLength(0);
+    expect(result.ir.metadata.name).toBe('');
+    expect(result.ir.metadata.version).toBe('0.0.0');
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('returns empty IR with metadata override for empty input', () => {
+    const result = mergeIrs([], { name: 'custom', version: '2.0.0' });
+    expect(result.ir.metadata.name).toBe('custom');
+    expect(result.ir.metadata.version).toBe('2.0.0');
+  });
+
+  it('concatenates contexts from multiple IRs', () => {
+    const ir1: IntermediateRepresentation = {
+      ...emptyIr(),
+      contexts: [
+        {
+          id: 'ctx-A',
+          name: 'A',
+          aggregates: [],
+          commands: [],
+          events: [],
+          valueObjects: [],
+          invariants: [],
+          policies: [],
+          sagas: [],
+          domainServices: [],
+        } as any,
+      ],
+    };
+    const ir2: IntermediateRepresentation = {
+      ...emptyIr(),
+      contexts: [
+        {
+          id: 'ctx-B',
+          name: 'B',
+          aggregates: [],
+          commands: [],
+          events: [],
+          valueObjects: [],
+          invariants: [],
+          policies: [],
+          sagas: [],
+          domainServices: [],
+        } as any,
+      ],
+    };
+    const result = mergeIrs([ir1, ir2]);
+    expect(result.ir.contexts).toHaveLength(2);
+    expect(result.ir.contexts[0].name).toBe('A');
+    expect(result.ir.contexts[1].name).toBe('B');
+  });
+
+  it('detects duplicate context names', () => {
+    const ir1: IntermediateRepresentation = {
+      ...emptyIr(),
+      contexts: [{ id: 'ctx-Dup', name: 'Dup', aggregates: [] } as any],
+    };
+    const ir2: IntermediateRepresentation = {
+      ...emptyIr(),
+      contexts: [{ id: 'ctx-Dup', name: 'Dup', aggregates: [] } as any],
+    };
+    const result = mergeIrs([ir1, ir2]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].ruleId).toBe('PM-01');
+    expect(result.diagnostics[0].message).toContain('Duplicate context name');
+  });
+
+  it('uses first IR metadata when no override', () => {
+    const ir1 = emptyIr('first');
+    const ir2 = emptyIr('second');
+    const result = mergeIrs([ir1, ir2]);
+    expect(result.ir.metadata.name).toBe('first');
+  });
+
+  it('applies metadata override over first IR', () => {
+    const ir1 = emptyIr('first');
+    const result = mergeIrs([ir1], { name: 'overridden', description: 'desc' });
+    expect(result.ir.metadata.name).toBe('overridden');
+    expect(result.ir.metadata.description).toBe('desc');
+  });
+
+  it('concatenates glossary and relationships', () => {
+    const ir1: IntermediateRepresentation = {
+      ...emptyIr(),
+      glossary: [{ term: 'A', definition: 'def A' }],
+      relationships: [
+        {
+          sourceContextId: 'ctx-X',
+          targetContextId: 'ctx-Y',
+          relationshipType: 'CS',
+          contract: '',
+        },
+      ],
+    };
+    const ir2: IntermediateRepresentation = {
+      ...emptyIr(),
+      glossary: [{ term: 'B', definition: 'def B' }],
+      relationships: [],
+    };
+    const result = mergeIrs([ir1, ir2]);
+    expect(result.ir.glossary).toHaveLength(2);
+    expect(result.ir.relationships).toHaveLength(1);
+  });
+});

--- a/packages/core/__tests__/project/project-loader.spec.ts
+++ b/packages/core/__tests__/project/project-loader.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { ProjectLoader } from '../../src/project/index.js';
+
+const FIXTURES = resolve(import.meta.dirname, '../../../../fixtures');
+const MINIMAL_CONTEXTS = resolve(FIXTURES, 'valid/minimal/contexts');
+const MINIMAL_FLOWS = resolve(FIXTURES, 'valid/minimal/flows');
+const MULTI_CONTEXT = resolve(FIXTURES, 'valid/multi-context');
+
+describe('ProjectLoader', () => {
+  const loader = new ProjectLoader();
+
+  describe('multi-file loading', () => {
+    it('merges contexts from multiple files into one IR', async () => {
+      const result = await loader.loadProject([
+        resolve(MINIMAL_CONTEXTS, 'ordering.moment'),
+        resolve(MINIMAL_CONTEXTS, 'fulfillment.moment'),
+      ]);
+
+      expect(result.success).toBe(true);
+      expect(result.ir.contexts).toHaveLength(2);
+      expect(result.filesParsed).toBe(2);
+      expect(result.filesErrored).toBe(0);
+
+      const names = result.ir.contexts.map((c) => c.name).sort();
+      expect(names).toEqual(['Fulfillment', 'Ordering']);
+    });
+
+    it('merges contexts + flows from separate files', async () => {
+      const result = await loader.loadProject([
+        resolve(MINIMAL_CONTEXTS, 'ordering.moment'),
+        resolve(MINIMAL_CONTEXTS, 'fulfillment.moment'),
+        resolve(MINIMAL_FLOWS, 'order-placed.moment'),
+      ]);
+
+      expect(result.success).toBe(true);
+      expect(result.ir.contexts).toHaveLength(2);
+      expect(result.ir.flows).toHaveLength(1);
+      expect(result.ir.flows[0].name).toBe('order-placed');
+    });
+
+    it('sorts files lexicographically for deterministic merge order', async () => {
+      // Pass files in reverse order — result should still be sorted.
+      const result = await loader.loadProject([
+        resolve(MINIMAL_CONTEXTS, 'ordering.moment'),
+        resolve(MINIMAL_CONTEXTS, 'fulfillment.moment'),
+      ]);
+
+      const reversed = await loader.loadProject([
+        resolve(MINIMAL_CONTEXTS, 'fulfillment.moment'),
+        resolve(MINIMAL_CONTEXTS, 'ordering.moment'),
+      ]);
+
+      // Both should produce the same context order.
+      expect(result.ir.contexts.map((c) => c.name)).toEqual(
+        reversed.ir.contexts.map((c) => c.name),
+      );
+    });
+  });
+
+  describe('cross-file validation', () => {
+    it('validates that flow lane contexts exist in the merged IR', async () => {
+      const result = await loader.loadProject([
+        resolve(MINIMAL_CONTEXTS, 'ordering.moment'),
+        resolve(MINIMAL_CONTEXTS, 'fulfillment.moment'),
+        resolve(MINIMAL_FLOWS, 'order-placed.moment'),
+      ]);
+
+      // The flow references both Ordering and Fulfillment contexts via
+      // lanes. Both exist in the merged IR, so validation should pass.
+      expect(result.success).toBe(true);
+      const crossFileErrors = result.diagnostics.filter(
+        (d) => d.ruleId?.startsWith('PM-') && d.severity === 'error',
+      );
+      expect(crossFileErrors).toHaveLength(0);
+    });
+
+    it('reports unresolved lane context references', async () => {
+      // Load the flow WITHOUT the fulfillment context — the flow
+      // references Fulfillment via a lane, which won't resolve.
+      const result = await loader.loadProject([
+        resolve(MINIMAL_CONTEXTS, 'ordering.moment'),
+        resolve(MINIMAL_FLOWS, 'order-placed.moment'),
+      ]);
+
+      // The flow should parse successfully (per-file parsing is lenient
+      // about cross-file refs), but cross-file validation should flag
+      // the unresolved ctx-Fulfillment reference.
+      const crossFileErrors = result.diagnostics.filter(
+        (d) => d.ruleId === 'PM-02' || d.ruleId === 'PM-03' || d.ruleId === 'PM-05',
+      );
+      expect(crossFileErrors.length).toBeGreaterThan(0);
+      expect(crossFileErrors.some((d) => d.message.includes('Fulfillment'))).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    it('reports file-read errors without blocking other files', async () => {
+      const result = await loader.loadProject([
+        resolve(MINIMAL_CONTEXTS, 'ordering.moment'),
+        resolve(MINIMAL_CONTEXTS, 'nonexistent-file.moment'),
+      ]);
+
+      expect(result.filesErrored).toBe(1);
+      expect(result.filesParsed).toBe(1);
+      expect(result.ir.contexts.length).toBeGreaterThan(0);
+      expect(result.diagnostics.some((d) => d.ruleId === 'PM-00')).toBe(true);
+    });
+
+    it('returns empty IR for empty file list', async () => {
+      const result = await loader.loadProject([]);
+
+      expect(result.success).toBe(true);
+      expect(result.ir.contexts).toHaveLength(0);
+      expect(result.ir.flows).toHaveLength(0);
+      expect(result.filesParsed).toBe(0);
+    });
+  });
+
+  describe('multi-context fixture (3 contexts + flow with crossings)', () => {
+    it('loads the multi-context fixture end-to-end', async () => {
+      const result = await loader.loadProject([
+        resolve(MULTI_CONTEXT, 'contexts/ordering.moment'),
+        resolve(MULTI_CONTEXT, 'contexts/fulfillment.moment'),
+        resolve(MULTI_CONTEXT, 'contexts/shipping.moment'),
+        resolve(MULTI_CONTEXT, 'flows/order-to-shipment.moment'),
+      ]);
+
+      expect(result.success).toBe(true);
+      expect(result.ir.contexts).toHaveLength(3);
+      expect(result.ir.flows).toHaveLength(1);
+      expect(result.ir.flows[0].connections.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/core/__tests__/project/project-loader.spec.ts
+++ b/packages/core/__tests__/project/project-loader.spec.ts
@@ -117,6 +117,24 @@ describe('ProjectLoader', () => {
     });
   });
 
+  describe('metadata merge', () => {
+    it('uses metadata override when provided', async () => {
+      const result = await loader.loadProject([resolve(MINIMAL_CONTEXTS, 'ordering.moment')], {
+        name: 'overridden',
+        version: '9.9.9',
+      });
+
+      expect(result.ir.metadata.name).toBe('overridden');
+      expect(result.ir.metadata.version).toBe('9.9.9');
+    });
+
+    it('uses first file metadata when no override provided', async () => {
+      const result = await loader.loadProject([resolve(MINIMAL_CONTEXTS, 'ordering.moment')]);
+
+      expect(result.ir.metadata).toBeDefined();
+    });
+  });
+
   describe('multi-context fixture (3 contexts + flow with crossings)', () => {
     it('loads the multi-context fixture end-to-end', async () => {
       const result = await loader.loadProject([

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,3 +12,5 @@ export {
   type SiftTimelineEvent,
   type SiftImportInput,
 } from './import/index.js';
+export { ProjectLoader, mergeIrs, validateCrossFileReferences } from './project/index.js';
+export type { ProjectLoadResult, MergeResult, CrossFileValidationResult } from './project/index.js';

--- a/packages/core/src/project/cross-file-validator.ts
+++ b/packages/core/src/project/cross-file-validator.ts
@@ -1,0 +1,170 @@
+/**
+ * CrossFileValidator — post-merge validation of cross-file references.
+ *
+ * Runs on the merged IR after all files have been parsed independently
+ * and their IRs concatenated. Checks that every cross-file reference
+ * (flow lanes → contexts, crossings → target contexts, relationships)
+ * resolves to an entity that actually exists in the merged IR.
+ *
+ * Per ADR-034 G8: this is a dedicated post-merge pass, NOT a re-run of
+ * the Langium validators. The Langium validators run per-file during
+ * parsing and accept unresolved cross-file refs as warnings. This
+ * validator promotes those warnings to errors when the merged IR proves
+ * the reference is genuinely unresolvable.
+ */
+
+import type { IntermediateRepresentation, FlowDefinition, Diagnostic } from '../ir/index.js';
+
+export interface CrossFileValidationResult {
+  readonly valid: boolean;
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+/** Build the set of known context IDs from the merged contexts. */
+function buildKnownContextIds(ir: IntermediateRepresentation): Set<string> {
+  return new Set(ir.contexts.map((c) => c.id));
+}
+
+/** Build event names per context for crossing validation. */
+function buildEventsByContext(ir: IntermediateRepresentation): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+  for (const ctx of ir.contexts) {
+    const events = new Set<string>();
+    for (const agg of ctx.aggregates) {
+      for (const evt of agg.events) events.add(evt.name);
+    }
+    result.set(ctx.id, events);
+  }
+  return result;
+}
+
+/** Collect context IDs from branch-lanes and terminal lanes (not real contexts). */
+function buildBranchLaneContextIds(ir: IntermediateRepresentation): Set<string> {
+  const ids = new Set<string>();
+  for (const flow of ir.flows) {
+    for (const lane of flow.lanes) {
+      if (lane.isBranch || lane.classification === 'Terminal') {
+        ids.add(lane.contextId);
+      }
+    }
+  }
+  return ids;
+}
+
+/** Validate that each non-branch lane's contextId exists. */
+function validateLanes(
+  flow: FlowDefinition,
+  knownContextIds: Set<string>,
+  diagnostics: Diagnostic[],
+): void {
+  for (const lane of flow.lanes) {
+    if (lane.isBranch || lane.classification === 'Terminal') continue;
+    if (!knownContextIds.has(lane.contextId)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Flow '${flow.name}', lane '${lane.id}': references context '${lane.label}' (${lane.contextId}) which is not defined in any loaded file.`,
+        ruleId: 'PM-02',
+      });
+    }
+  }
+}
+
+/** Validate that crossing connections target existing contexts and events. */
+function validateConnections(
+  flow: FlowDefinition,
+  knownContextIds: Set<string>,
+  eventsByContext: Map<string, Set<string>>,
+  diagnostics: Diagnostic[],
+): void {
+  for (const conn of flow.connections) {
+    if (!knownContextIds.has(conn.targetContextId)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Flow '${flow.name}', connection '${conn.id}': target context '${conn.targetContextId}' is not defined in any loaded file.`,
+        ruleId: 'PM-03',
+      });
+    }
+    if (conn.connectionType === 'crosses-to') {
+      const targetEvents = eventsByContext.get(conn.targetContextId);
+      const eventName = conn.eventId.replace(/^evt-/, '');
+      if (targetEvents && !targetEvents.has(eventName)) {
+        diagnostics.push({
+          severity: 'warning',
+          message: `Flow '${flow.name}': crossing event '${eventName}' is not declared in target context '${conn.targetContextId}'.`,
+          ruleId: 'PM-04',
+        });
+      }
+    }
+  }
+}
+
+/** Validate that moment entries reference existing contexts. */
+function validateMomentEntries(
+  flow: FlowDefinition,
+  knownContextIds: Set<string>,
+  branchLaneContextIds: Set<string>,
+  diagnostics: Diagnostic[],
+): void {
+  for (const moment of flow.moments) {
+    for (const entry of moment.contextEntries) {
+      if (branchLaneContextIds.has(entry.contextId)) continue;
+      if (entry.terminal) continue;
+      if (!knownContextIds.has(entry.contextId)) {
+        diagnostics.push({
+          severity: 'error',
+          message: `Flow '${flow.name}', moment '${moment.name}': node '${entry.nodeName}' references context '${entry.contextId}' which is not defined in any loaded file.`,
+          ruleId: 'PM-05',
+        });
+      }
+    }
+  }
+}
+
+/** Validate that relationship endpoints reference existing contexts. */
+function validateRelationships(
+  ir: IntermediateRepresentation,
+  knownContextIds: Set<string>,
+  diagnostics: Diagnostic[],
+): void {
+  for (const rel of ir.relationships) {
+    if (!knownContextIds.has(rel.sourceContextId)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Relationship: source context '${rel.sourceContextId}' is not defined in any loaded file.`,
+        ruleId: 'PM-06',
+      });
+    }
+    if (!knownContextIds.has(rel.targetContextId)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Relationship: target context '${rel.targetContextId}' is not defined in any loaded file.`,
+        ruleId: 'PM-06',
+      });
+    }
+  }
+}
+
+/**
+ * Validate that all cross-file references in a merged IR resolve to
+ * entities that exist in the merged contexts/flows/relationships.
+ */
+export function validateCrossFileReferences(
+  ir: IntermediateRepresentation,
+): CrossFileValidationResult {
+  const diagnostics: Diagnostic[] = [];
+  const knownContextIds = buildKnownContextIds(ir);
+  const eventsByContext = buildEventsByContext(ir);
+  const branchLaneContextIds = buildBranchLaneContextIds(ir);
+
+  for (const flow of ir.flows) {
+    validateLanes(flow, knownContextIds, diagnostics);
+    validateConnections(flow, knownContextIds, eventsByContext, diagnostics);
+    validateMomentEntries(flow, knownContextIds, branchLaneContextIds, diagnostics);
+  }
+  validateRelationships(ir, knownContextIds, diagnostics);
+
+  return {
+    valid: diagnostics.filter((d) => d.severity === 'error').length === 0,
+    diagnostics,
+  };
+}

--- a/packages/core/src/project/cross-file-validator.ts
+++ b/packages/core/src/project/cross-file-validator.ts
@@ -25,15 +25,13 @@ function buildKnownContextIds(ir: IntermediateRepresentation): Set<string> {
   return new Set(ir.contexts.map((c) => c.id));
 }
 
-/** Build event names per context for crossing validation. */
+/** Build event names per context for crossing validation. Uses the
+ *  flattened ctx.events rather than walking aggregates — simpler and
+ *  resilient if event modeling changes. */
 function buildEventsByContext(ir: IntermediateRepresentation): Map<string, Set<string>> {
   const result = new Map<string, Set<string>>();
   for (const ctx of ir.contexts) {
-    const events = new Set<string>();
-    for (const agg of ctx.aggregates) {
-      for (const evt of agg.events) events.add(evt.name);
-    }
-    result.set(ctx.id, events);
+    result.set(ctx.id, new Set(ctx.events.map((evt) => evt.name)));
   }
   return result;
 }
@@ -69,7 +67,8 @@ function validateLanes(
   }
 }
 
-/** Validate that crossing connections target existing contexts and events. */
+/** Validate crossing connections only — non-crossing connections reference
+ *  their own lane's context which is already covered by PM-02. */
 function validateConnections(
   flow: FlowDefinition,
   knownContextIds: Set<string>,
@@ -77,28 +76,48 @@ function validateConnections(
   diagnostics: Diagnostic[],
 ): void {
   for (const conn of flow.connections) {
+    if (conn.connectionType !== 'crosses-to') continue;
     if (!knownContextIds.has(conn.targetContextId)) {
       diagnostics.push({
         severity: 'error',
         message: `Flow '${flow.name}', connection '${conn.id}': target context '${conn.targetContextId}' is not defined in any loaded file.`,
         ruleId: 'PM-03',
       });
+      continue;
     }
-    if (conn.connectionType === 'crosses-to') {
-      const targetEvents = eventsByContext.get(conn.targetContextId);
-      const eventName = conn.eventId.replace(/^evt-/, '');
-      if (targetEvents && !targetEvents.has(eventName)) {
-        diagnostics.push({
-          severity: 'warning',
-          message: `Flow '${flow.name}': crossing event '${eventName}' is not declared in target context '${conn.targetContextId}'.`,
-          ruleId: 'PM-04',
-        });
-      }
+    const targetEvents = eventsByContext.get(conn.targetContextId);
+    const eventName = conn.eventId.replace(/^evt-/, '');
+    if (targetEvents && !targetEvents.has(eventName)) {
+      diagnostics.push({
+        severity: 'warning',
+        message: `Flow '${flow.name}': crossing event '${eventName}' is not declared in target context '${conn.targetContextId}'.`,
+        ruleId: 'PM-04',
+      });
     }
   }
 }
 
-/** Validate that moment entries reference existing contexts. */
+/** Check a single context entry against known IDs, skipping synthetic lane contexts. */
+function checkEntry(
+  flowName: string,
+  momentName: string,
+  entry: { contextId: string; nodeName: string },
+  knownContextIds: Set<string>,
+  branchLaneContextIds: Set<string>,
+  diagnostics: Diagnostic[],
+): void {
+  if (branchLaneContextIds.has(entry.contextId)) return;
+  if (!knownContextIds.has(entry.contextId)) {
+    diagnostics.push({
+      severity: 'error',
+      message: `Flow '${flowName}', moment '${momentName}': node '${entry.nodeName}' references context '${entry.contextId}' which is not defined in any loaded file.`,
+      ruleId: 'PM-05',
+    });
+  }
+}
+
+/** Validate that moment entries (including branch when-block entries)
+ *  reference existing contexts. */
 function validateMomentEntries(
   flow: FlowDefinition,
   knownContextIds: Set<string>,
@@ -107,14 +126,21 @@ function validateMomentEntries(
 ): void {
   for (const moment of flow.moments) {
     for (const entry of moment.contextEntries) {
-      if (branchLaneContextIds.has(entry.contextId)) continue;
-      if (entry.terminal) continue;
-      if (!knownContextIds.has(entry.contextId)) {
-        diagnostics.push({
-          severity: 'error',
-          message: `Flow '${flow.name}', moment '${moment.name}': node '${entry.nodeName}' references context '${entry.contextId}' which is not defined in any loaded file.`,
-          ruleId: 'PM-05',
-        });
+      checkEntry(flow.name, moment.name, entry, knownContextIds, branchLaneContextIds, diagnostics);
+    }
+    // Also validate entries inside branch when-blocks.
+    if (moment.branches) {
+      for (const branch of moment.branches) {
+        for (const entry of branch.entries) {
+          checkEntry(
+            flow.name,
+            moment.name,
+            entry,
+            knownContextIds,
+            branchLaneContextIds,
+            diagnostics,
+          );
+        }
       }
     }
   }

--- a/packages/core/src/project/index.ts
+++ b/packages/core/src/project/index.ts
@@ -1,0 +1,6 @@
+export { ProjectLoader } from './project-loader.js';
+export type { ProjectLoadResult } from './project-loader.js';
+export { mergeIrs } from './ir-merger.js';
+export type { MergeResult } from './ir-merger.js';
+export { validateCrossFileReferences } from './cross-file-validator.js';
+export type { CrossFileValidationResult } from './cross-file-validator.js';

--- a/packages/core/src/project/ir-merger.ts
+++ b/packages/core/src/project/ir-merger.ts
@@ -49,7 +49,7 @@ function detectDuplicateContexts(irs: readonly IntermediateRepresentation[]): Di
       if (existing !== undefined) {
         diagnostics.push({
           severity: 'error',
-          message: `Duplicate context name '${ctx.name}' — declared in file ${existing + 1} and file ${i + 1}. Each context must be defined in exactly one file.`,
+          message: `Duplicate context name '${ctx.name}' — declared in IR #${existing + 1} and IR #${i + 1}. Each context must be defined in exactly one file.`,
           ruleId: 'PM-01',
         });
       } else {

--- a/packages/core/src/project/ir-merger.ts
+++ b/packages/core/src/project/ir-merger.ts
@@ -1,0 +1,90 @@
+/**
+ * IR Merger — pure function that combines N IntermediateRepresentations
+ * into one, with deterministic ordering and duplicate detection.
+ *
+ * Rules (from ADR-034 G1):
+ *   - contexts[], flows[], glossary[], relationships[] are concatenated
+ *   - Merge order follows the order of the input array (caller sorts by
+ *     file path for determinism)
+ *   - Duplicate context names across IRs produce a diagnostic error
+ *   - metadata uses the first IR's metadata (caller can override)
+ */
+
+import type { IntermediateRepresentation, SpecificationMetadata, Diagnostic } from '../ir/index.js';
+
+export interface MergeResult {
+  readonly ir: IntermediateRepresentation;
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+/**
+ * Merge N independently-parsed IRs into a single combined IR.
+ *
+ * The input array's order is authoritative — `irs[0]`'s contexts appear
+ * before `irs[1]`'s in the merged output. The caller is responsible for
+ * sorting the input (typically by file path, lexicographically) to ensure
+ * deterministic output across platforms.
+ */
+const EMPTY_METADATA: SpecificationMetadata = { name: '', version: '0.0.0' };
+
+/** Build the merged metadata, preferring overrides then first IR's values. */
+function resolveMetadata(
+  baseMetadata: SpecificationMetadata,
+  override?: Partial<SpecificationMetadata>,
+): SpecificationMetadata {
+  return {
+    name: override?.name ?? baseMetadata.name,
+    version: override?.version ?? baseMetadata.version,
+    description: override?.description ?? baseMetadata.description,
+  };
+}
+
+/** Detect duplicate context names across IRs. */
+function detectDuplicateContexts(irs: readonly IntermediateRepresentation[]): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  const seen = new Map<string, number>();
+  for (let i = 0; i < irs.length; i++) {
+    for (const ctx of irs[i].contexts) {
+      const existing = seen.get(ctx.name);
+      if (existing !== undefined) {
+        diagnostics.push({
+          severity: 'error',
+          message: `Duplicate context name '${ctx.name}' — declared in file ${existing + 1} and file ${i + 1}. Each context must be defined in exactly one file.`,
+          ruleId: 'PM-01',
+        });
+      } else {
+        seen.set(ctx.name, i);
+      }
+    }
+  }
+  return diagnostics;
+}
+
+export function mergeIrs(
+  irs: readonly IntermediateRepresentation[],
+  metadataOverride?: Partial<SpecificationMetadata>,
+): MergeResult {
+  if (irs.length === 0) {
+    return {
+      ir: {
+        contexts: [],
+        flows: [],
+        glossary: [],
+        relationships: [],
+        metadata: resolveMetadata(EMPTY_METADATA, metadataOverride),
+      },
+      diagnostics: [],
+    };
+  }
+
+  return {
+    ir: {
+      contexts: irs.flatMap((ir) => ir.contexts),
+      flows: irs.flatMap((ir) => ir.flows),
+      glossary: irs.flatMap((ir) => ir.glossary),
+      relationships: irs.flatMap((ir) => ir.relationships),
+      metadata: resolveMetadata(irs[0].metadata, metadataOverride),
+    },
+    diagnostics: detectDuplicateContexts(irs),
+  };
+}

--- a/packages/core/src/project/project-loader.ts
+++ b/packages/core/src/project/project-loader.ts
@@ -1,0 +1,136 @@
+/**
+ * ProjectLoader — loads multiple .moment files and produces a single
+ * merged IntermediateRepresentation with cross-file validation.
+ *
+ * This is the entry point for project-mode execution (ADR-032 R2,
+ * ADR-034 G1). It replaces the single-file `MomentParser.parseContent()`
+ * path with a multi-file pipeline:
+ *
+ *   1. Sort file paths lexicographically (deterministic merge order)
+ *   2. Read and parse each file independently via MomentParser
+ *   3. Merge all successful IRs via irMerger (concatenate arrays)
+ *   4. Run CrossFileValidator on the merged IR
+ *   5. Return the merged IR + aggregated diagnostics
+ *
+ * Files with parse errors are included in the diagnostics but do NOT
+ * block the merge of other files (fail-open per-file, fail-closed for
+ * the aggregate if any file has errors).
+ */
+
+import { readFileSync } from 'node:fs';
+import { MomentParser } from '../parser/index.js';
+import type { IntermediateRepresentation, Diagnostic, SpecificationMetadata } from '../ir/index.js';
+import { mergeIrs } from './ir-merger.js';
+import { validateCrossFileReferences } from './cross-file-validator.js';
+
+export interface ProjectLoadResult {
+  /** True if all files parsed successfully and cross-file validation passed. */
+  readonly success: boolean;
+  /** The merged IR from all successfully-parsed files. */
+  readonly ir: IntermediateRepresentation;
+  /** Aggregated diagnostics from all files + merge + cross-file validation. */
+  readonly diagnostics: readonly Diagnostic[];
+  /** Number of files that parsed successfully. */
+  readonly filesParsed: number;
+  /** Number of files that had parse errors. */
+  readonly filesErrored: number;
+}
+
+export class ProjectLoader {
+  private readonly parser: MomentParser;
+
+  constructor(parser?: MomentParser) {
+    this.parser = parser ?? new MomentParser();
+  }
+
+  /**
+   * Load and merge multiple .moment files into a single IR.
+   *
+   * @param filePaths Absolute or relative paths to .moment files.
+   *   Order doesn't matter — paths are sorted lexicographically internally
+   *   for deterministic merge order.
+   * @param metadataOverride Optional metadata to use instead of deriving
+   *   from the first file (useful when the manifest provides name/version).
+   */
+  async loadProject(
+    filePaths: readonly string[],
+    metadataOverride?: Partial<SpecificationMetadata>,
+  ): Promise<ProjectLoadResult> {
+    const sortedPaths = [...filePaths].sort();
+    const allDiagnostics: Diagnostic[] = [];
+    const successfulIrs: IntermediateRepresentation[] = [];
+    let filesErrored = 0;
+
+    // Phase 1: Parse each file independently.
+    for (const filePath of sortedPaths) {
+      const parseResult = await this.parseFile(filePath);
+      allDiagnostics.push(...parseResult.diagnostics);
+
+      if (parseResult.success && parseResult.ir) {
+        successfulIrs.push(parseResult.ir);
+      } else {
+        filesErrored++;
+      }
+    }
+
+    // Phase 2: Merge all successful IRs.
+    const mergeResult = mergeIrs(successfulIrs, metadataOverride);
+    allDiagnostics.push(...mergeResult.diagnostics);
+
+    // Phase 3: Cross-file validation on the merged IR.
+    const validationResult = validateCrossFileReferences(mergeResult.ir);
+    allDiagnostics.push(...validationResult.diagnostics);
+
+    const hasErrors = allDiagnostics.some((d) => d.severity === 'error');
+
+    return {
+      success: !hasErrors,
+      ir: mergeResult.ir,
+      diagnostics: allDiagnostics,
+      filesParsed: successfulIrs.length,
+      filesErrored,
+    };
+  }
+
+  /**
+   * Parse a single file, attaching the file path to any diagnostics
+   * so multi-file error messages are traceable.
+   */
+  private async parseFile(
+    filePath: string,
+  ): Promise<{ success: boolean; ir?: IntermediateRepresentation; diagnostics: Diagnostic[] }> {
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        diagnostics: [
+          {
+            severity: 'error',
+            message: `Failed to read file: ${msg}`,
+            source: { file: filePath, line: 0, column: 0 },
+            ruleId: 'PM-00',
+          },
+        ],
+      };
+    }
+
+    const result = await this.parser.parseContent(content);
+
+    // Attach the file path to any diagnostics that don't already have one.
+    const diagnostics: Diagnostic[] = result.diagnostics.map((d) => ({
+      ...d,
+      source: d.source
+        ? { ...d.source, file: d.source.file || filePath }
+        : { file: filePath, line: 0, column: 0 },
+    }));
+
+    return {
+      success: result.success,
+      ir: result.ir,
+      diagnostics,
+    };
+  }
+}

--- a/packages/core/src/project/project-loader.ts
+++ b/packages/core/src/project/project-loader.ts
@@ -50,7 +50,8 @@ export class ProjectLoader {
    *   Order doesn't matter — paths are sorted lexicographically internally
    *   for deterministic merge order.
    * @param metadataOverride Optional metadata to use instead of deriving
-   *   from the first file (useful when the manifest provides name/version).
+   *   from the first successfully parsed file (useful when the manifest
+   *   provides name/version).
    */
   async loadProject(
     filePaths: readonly string[],


### PR DESCRIPTION
## MMNT-5429 — Phase 1.1: ProjectLoader

**Jira:** [MMNT-5429](https://winnovation.atlassian.net/browse/MMNT-5429)
**Epic:** [MMNT-5418](https://winnovation.atlassian.net/browse/MMNT-5418) — Project-level execution and expanded generator registry
**ADRs:** ADR-032 R2, ADR-034 G1 + G8

The Phase 1 foundation that unblocks project-mode execution for all CLI commands. Without this, no command can operate on a multi-file project.

## What it does

New `ProjectLoader` class in `@mmmnt/core` that loads N `.moment` files and produces a single merged `IntermediateRepresentation`:

```typescript
import { ProjectLoader } from '@mmmnt/core';

const loader = new ProjectLoader();
const result = await loader.loadProject([
  'contexts/ordering.moment',
  'contexts/fulfillment.moment',
  'flows/order-placed.moment',
]);
// result.ir.contexts.length === 2
// result.ir.flows.length === 1
```

### Three modules in `packages/core/src/project/`

| Module | What |
|---|---|
| **`ProjectLoader`** | Reads N files, parses each via `MomentParser`, merges IRs, runs cross-file validation, returns `ProjectLoadResult` |
| **`mergeIrs`** | Pure function: concatenates `contexts[]`, `flows[]`, `glossary[]`, `relationships[]` with deterministic ordering (sorted by file path). Detects duplicate context names (PM-01). |
| **`validateCrossFileReferences`** | Post-merge validator: checks lane contextIds (PM-02), crossing targetContextIds (PM-03), crossing event names (PM-04 warning), moment entry contextIds (PM-05), relationship endpoints (PM-06) |

### Design decisions from ADR-034

- **G1**: Parse each file independently, merge by array concatenation. Duplicate context names are an error.
- **G8**: Cross-file validation is a dedicated post-merge pass, not a re-run of Langium validators. Langium runs per-file and is lenient about cross-file refs; `CrossFileValidator` promotes unresolvable refs to errors.
- **G12**: File paths sorted lexicographically before parsing — merge order is deterministic across platforms.

### Branch/terminal lane handling

The multi-context fixture has `branch-lane` and `[Terminal]` lanes (e.g., `outOfStock "Out of Stock" [Terminal]`). These are flow-control constructs, not real bounded contexts. The cross-file validator skips them — `lane.isBranch` and `lane.classification === 'Terminal'` bypass PM-02/PM-05 checks.

## Test plan

- [x] 308/308 `@mmmnt/core` tests pass (8 new)
- [x] Lint clean
- [x] Build clean
- [x] Tested against `fixtures/valid/minimal/` (2 contexts + 1 flow) and `fixtures/valid/multi-context/` (3 contexts + 1 flow with crossings + terminal lanes)
- [x] Unresolved cross-file references (flow loaded without its referenced context) produce PM-02/PM-03/PM-05 diagnostics
- [x] Nonexistent file paths produce PM-00 diagnostic without blocking other files
- [x] Empty file list returns empty IR with success=true
- [ ] CI passes

## Changeset

Minor bump — new public API surface (`ProjectLoader`, `mergeIrs`, `validateCrossFileReferences`).


[MMNT-5429]: https://winnovation.atlassian.net/browse/MMNT-5429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMNT-5418]: https://winnovation.atlassian.net/browse/MMNT-5418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ