### PR TITLE
feat(core): generator registry with DAG planner and descriptor interfaces

### DIFF
--- a/.changeset/generator-registry.md
+++ b/.changeset/generator-registry.md
@@ -1,0 +1,24 @@
+---
+'@mmmnt/core': minor
+---
+
+**feat(core): GeneratorRegistry with DAG planner and descriptor interfaces**
+
+New open generator registry in `@mmmnt/core` replacing the hardcoded
+`ALLOWED_FORMATS` set (MMNT-5430 / ADR-032 R1 / ADR-034 G2+G3).
+
+- `GeneratorDescriptor` interface: `format`, `scope`, `dependsOn`,
+  `defaultOutputDir`, `run(ctx) → Promise<GeneratorRunResult>`
+- `GeneratorRunContext`: provides `ir`, `manifestDir`, `outputDir`,
+  `options`, and `upstreamOutputs` (results from declared dependencies)
+- `GeneratorRunResult`: returns `files: Map<string, string>` (in-memory)
+  + `diagnostics` — framework handles disk writes with path safety
+- `GeneratorRegistry` class: `register()`, `resolve()`, `has()`,
+  `getAll()`, `getFormats()`, `planExecutionOrder()`
+- Topological sort via Kahn's algorithm with cycle detection
+- Deterministic ordering: independent generators sort alphabetically
+
+Each generator package will export a `registerGenerators(registry)`
+function (next story). The CLI's project-mode bootstrap calls them all.
+No circular dependencies — `@mmmnt/core` exports only the interface +
+registry class.

--- a/packages/core/__tests__/generators/generator-registry.spec.ts
+++ b/packages/core/__tests__/generators/generator-registry.spec.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GeneratorRegistry } from '../../src/generators/index.js';
+import type { GeneratorDescriptor, GeneratorRunResult } from '../../src/generators/index.js';
+
+function makeDescriptor(
+  format: string,
+  overrides: Partial<GeneratorDescriptor> = {},
+): GeneratorDescriptor {
+  return {
+    format,
+    scope: 'project',
+    dependsOn: [],
+    defaultOutputDir: `generated/${format}`,
+    run: async () => ({ files: new Map(), diagnostics: [] }),
+    ...overrides,
+  };
+}
+
+describe('GeneratorRegistry', () => {
+  let registry: GeneratorRegistry;
+
+  beforeEach(() => {
+    registry = new GeneratorRegistry();
+  });
+
+  describe('register/resolve', () => {
+    it('registers and resolves a descriptor', () => {
+      const desc = makeDescriptor('typescript');
+      registry.register(desc);
+
+      expect(registry.resolve('typescript')).toBe(desc);
+    });
+
+    it('throws on duplicate registration', () => {
+      registry.register(makeDescriptor('typescript'));
+      expect(() => registry.register(makeDescriptor('typescript'))).toThrow(/already registered/);
+    });
+
+    it('throws on unknown format listing all registered', () => {
+      registry.register(makeDescriptor('gherkin'));
+      registry.register(makeDescriptor('typescript'));
+
+      expect(() => registry.resolve('unknown')).toThrow(
+        /Unknown generator format 'unknown'.*gherkin, typescript/,
+      );
+    });
+
+    it('throws with (none) when registry is empty', () => {
+      expect(() => registry.resolve('anything')).toThrow(/\(none\)/);
+    });
+  });
+
+  describe('has', () => {
+    it('returns true for registered formats', () => {
+      registry.register(makeDescriptor('typescript'));
+      expect(registry.has('typescript')).toBe(true);
+    });
+
+    it('returns false for unknown formats', () => {
+      expect(registry.has('unknown')).toBe(false);
+    });
+  });
+
+  describe('getAll / getFormats', () => {
+    it('returns all registered descriptors', () => {
+      registry.register(makeDescriptor('a'));
+      registry.register(makeDescriptor('b'));
+
+      expect(registry.getAll()).toHaveLength(2);
+    });
+
+    it('returns sorted format names', () => {
+      registry.register(makeDescriptor('zebra'));
+      registry.register(makeDescriptor('alpha'));
+
+      expect(registry.getFormats()).toEqual(['alpha', 'zebra']);
+    });
+  });
+
+  describe('planExecutionOrder', () => {
+    it('returns topologically sorted array respecting dependencies', () => {
+      // topology has no deps, test-scaffold depends on topology
+      registry.register(makeDescriptor('topology'));
+      registry.register(makeDescriptor('test-scaffold', { dependsOn: ['topology'] }));
+
+      const order = registry.planExecutionOrder();
+      expect(order.indexOf('topology')).toBeLessThan(order.indexOf('test-scaffold'));
+    });
+
+    it('handles a diamond dependency graph', () => {
+      // A → B, A → C, B → D, C → D
+      registry.register(makeDescriptor('A'));
+      registry.register(makeDescriptor('B', { dependsOn: ['A'] }));
+      registry.register(makeDescriptor('C', { dependsOn: ['A'] }));
+      registry.register(makeDescriptor('D', { dependsOn: ['B', 'C'] }));
+
+      const order = registry.planExecutionOrder();
+      expect(order[0]).toBe('A');
+      expect(order[order.length - 1]).toBe('D');
+      expect(order.indexOf('B')).toBeLessThan(order.indexOf('D'));
+      expect(order.indexOf('C')).toBeLessThan(order.indexOf('D'));
+    });
+
+    it('detects dependency cycles', () => {
+      registry.register(makeDescriptor('A', { dependsOn: ['B'] }));
+      registry.register(makeDescriptor('B', { dependsOn: ['A'] }));
+
+      expect(() => registry.planExecutionOrder()).toThrow(/Dependency cycle detected.*A, B/);
+    });
+
+    it('handles no dependencies (alphabetical order)', () => {
+      registry.register(makeDescriptor('zebra'));
+      registry.register(makeDescriptor('alpha'));
+      registry.register(makeDescriptor('middle'));
+
+      const order = registry.planExecutionOrder();
+      expect(order).toEqual(['alpha', 'middle', 'zebra']);
+    });
+
+    it('plans only requested formats when specified', () => {
+      registry.register(makeDescriptor('topology'));
+      registry.register(makeDescriptor('test-scaffold', { dependsOn: ['topology'] }));
+      registry.register(makeDescriptor('gherkin'));
+
+      const order = registry.planExecutionOrder(['topology', 'test-scaffold']);
+      expect(order).toEqual(['topology', 'test-scaffold']);
+      expect(order).not.toContain('gherkin');
+    });
+
+    it('ignores dependencies on formats not in the requested set', () => {
+      registry.register(makeDescriptor('topology'));
+      registry.register(makeDescriptor('test-scaffold', { dependsOn: ['topology'] }));
+
+      // Request only test-scaffold without topology — dep is ignored
+      const order = registry.planExecutionOrder(['test-scaffold']);
+      expect(order).toEqual(['test-scaffold']);
+    });
+
+    it('handles a single node with self-dependency as a cycle', () => {
+      registry.register(makeDescriptor('self-ref', { dependsOn: ['self-ref'] }));
+      expect(() => registry.planExecutionOrder()).toThrow(/Dependency cycle/);
+    });
+
+    it('handles formats not in registry gracefully in requested set', () => {
+      registry.register(makeDescriptor('topology'));
+      // Request a format that's registered + one that isn't
+      const order = registry.planExecutionOrder(['topology', 'ghost']);
+      // ghost has no descriptor so no edges — still appears in output
+      expect(order).toContain('topology');
+      expect(order).toContain('ghost');
+    });
+
+    it('handles the full R1 dependency graph without cycles', () => {
+      // Register all 13 V1 formats with their declared dependencies
+      registry.register(makeDescriptor('typescript', { scope: 'project' }));
+      registry.register(
+        makeDescriptor('test-scaffold', {
+          scope: 'flow',
+          dependsOn: ['topology'],
+        }),
+      );
+      registry.register(makeDescriptor('gherkin', { scope: 'flow' }));
+      registry.register(
+        makeDescriptor('cucumber-json', {
+          scope: 'flow',
+          dependsOn: ['gherkin'],
+        }),
+      );
+      registry.register(makeDescriptor('markdown', { scope: 'project' }));
+      registry.register(
+        makeDescriptor('asyncapi', {
+          scope: 'project',
+          dependsOn: ['event-catalog'],
+        }),
+      );
+      registry.register(makeDescriptor('topology', { scope: 'flow' }));
+      registry.register(makeDescriptor('event-catalog', { scope: 'project' }));
+      registry.register(makeDescriptor('saga', { scope: 'flow', dependsOn: ['topology'] }));
+      registry.register(
+        makeDescriptor('impact-analysis', {
+          scope: 'project',
+          dependsOn: ['topology', 'event-catalog'],
+        }),
+      );
+      registry.register(
+        makeDescriptor('simulation', {
+          scope: 'flow',
+          dependsOn: ['topology'],
+        }),
+      );
+      registry.register(makeDescriptor('facet', { scope: 'flow', dependsOn: ['topology'] }));
+      registry.register(makeDescriptor('viz', { scope: 'project' }));
+
+      const order = registry.planExecutionOrder();
+      expect(order).toHaveLength(13);
+
+      // Verify key ordering constraints
+      expect(order.indexOf('topology')).toBeLessThan(order.indexOf('test-scaffold'));
+      expect(order.indexOf('topology')).toBeLessThan(order.indexOf('facet'));
+      expect(order.indexOf('gherkin')).toBeLessThan(order.indexOf('cucumber-json'));
+      expect(order.indexOf('event-catalog')).toBeLessThan(order.indexOf('asyncapi'));
+      expect(order.indexOf('event-catalog')).toBeLessThan(order.indexOf('impact-analysis'));
+      expect(order.indexOf('topology')).toBeLessThan(order.indexOf('impact-analysis'));
+    });
+  });
+});

--- a/packages/core/__tests__/generators/generator-registry.spec.ts
+++ b/packages/core/__tests__/generators/generator-registry.spec.ts
@@ -141,6 +141,22 @@ describe('GeneratorRegistry', () => {
       expect(() => registry.planExecutionOrder()).toThrow(/Dependency cycle/);
     });
 
+    it('deduplicates requested formats', () => {
+      registry.register(makeDescriptor('topology'));
+      registry.register(makeDescriptor('test-scaffold', { dependsOn: ['topology'] }));
+
+      const order = registry.planExecutionOrder(['topology', 'topology', 'test-scaffold']);
+      expect(order).toEqual(['topology', 'test-scaffold']);
+    });
+
+    it('handles duplicate dependsOn entries without double-counting', () => {
+      registry.register(makeDescriptor('topology'));
+      registry.register(makeDescriptor('test-scaffold', { dependsOn: ['topology', 'topology'] }));
+
+      const order = registry.planExecutionOrder();
+      expect(order).toEqual(['topology', 'test-scaffold']);
+    });
+
     it('handles formats not in registry gracefully in requested set', () => {
       registry.register(makeDescriptor('topology'));
       // Request a format that's registered + one that isn't

--- a/packages/core/src/generators/generator-descriptor.ts
+++ b/packages/core/src/generators/generator-descriptor.ts
@@ -1,0 +1,61 @@
+/**
+ * Generator Descriptor — the contract each generator package implements.
+ *
+ * Per ADR-032 R1 and ADR-034 G2: generators return in-memory content
+ * (Map<string, string>) and the framework handles disk writes with
+ * centralized path safety via assertPathWithin.
+ */
+
+import type { IntermediateRepresentation, Diagnostic } from '../ir/index.js';
+
+export type GeneratorScope = 'context' | 'flow' | 'project';
+
+/**
+ * Context provided to a generator's run() function. The framework
+ * populates this based on the generator's declared scope and dependsOn.
+ */
+export interface GeneratorRunContext {
+  /** The merged IR from all project files. */
+  readonly ir: IntermediateRepresentation;
+  /** The manifest directory (for resolving relative paths). */
+  readonly manifestDir: string;
+  /** The resolved output directory for this generator. */
+  readonly outputDir: string;
+  /** Generator-specific options from the manifest's generators[].options. */
+  readonly options: Readonly<Record<string, unknown>>;
+  /**
+   * Results from upstream generators this one depends on (declared in
+   * dependsOn). Keyed by format name. Only populated for formats listed
+   * in the descriptor's dependsOn array.
+   */
+  readonly upstreamOutputs: ReadonlyMap<string, GeneratorRunResult>;
+}
+
+/**
+ * Result returned by a generator's run() function. Files are in-memory
+ * content keyed by relative path — the framework writes them to disk.
+ */
+export interface GeneratorRunResult {
+  /** Map of relative file path → file content. */
+  readonly files: ReadonlyMap<string, string>;
+  /** Diagnostics emitted during generation (warnings, info). */
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+/**
+ * A generator descriptor registered in the GeneratorRegistry. Each
+ * generator package exports a registerGenerators() function that
+ * creates and registers these descriptors.
+ */
+export interface GeneratorDescriptor {
+  /** Unique format identifier (e.g., "typescript", "gherkin", "facet"). */
+  readonly format: string;
+  /** Whether this generator runs per-context, per-flow, or once per project. */
+  readonly scope: GeneratorScope;
+  /** Formats this generator depends on (must run before this one). */
+  readonly dependsOn: readonly string[];
+  /** Default output directory when not overridden in the manifest. */
+  readonly defaultOutputDir: string;
+  /** The generator's execution function. */
+  readonly run: (ctx: GeneratorRunContext) => Promise<GeneratorRunResult>;
+}

--- a/packages/core/src/generators/generator-descriptor.ts
+++ b/packages/core/src/generators/generator-descriptor.ts
@@ -3,7 +3,7 @@
  *
  * Per ADR-032 R1 and ADR-034 G2: generators return in-memory content
  * (Map<string, string>) and the framework handles disk writes with
- * centralized path safety via assertPathWithin.
+ * centralized path safety (the CLI's assertPathWithin helper).
  */
 
 import type { IntermediateRepresentation, Diagnostic } from '../ir/index.js';

--- a/packages/core/src/generators/generator-registry.ts
+++ b/packages/core/src/generators/generator-registry.ts
@@ -1,5 +1,6 @@
 /**
- * GeneratorRegistry — open registry replacing the hardcoded ALLOWED_FORMATS.
+ * GeneratorRegistry — open registry that will replace the hardcoded
+ * ALLOWED_FORMATS once manifest schema v2 lands (MMNT-5431).
  *
  * Per ADR-032 R1 and ADR-034 G3: @mmmnt/core exports the interface +
  * registry class. Each generator package exports a registerGenerators()
@@ -56,14 +57,17 @@ export class GeneratorRegistry {
    * order for determinism.
    */
   planExecutionOrder(requestedFormats?: readonly string[]): string[] {
-    const formats = requestedFormats ? [...requestedFormats] : [...this.descriptors.keys()];
+    const formats = requestedFormats
+      ? [...new Set(requestedFormats)]
+      : [...this.descriptors.keys()];
 
     // Build adjacency list from dependsOn edges.
-    const graph = new Map<string, string[]>();
+    const formatSet = new Set(formats);
+    const graph = new Map<string, Set<string>>();
     const inDegree = new Map<string, number>();
 
     for (const format of formats) {
-      if (!graph.has(format)) graph.set(format, []);
+      if (!graph.has(format)) graph.set(format, new Set());
       if (!inDegree.has(format)) inDegree.set(format, 0);
     }
 
@@ -71,7 +75,7 @@ export class GeneratorRegistry {
       const descriptor = this.descriptors.get(format);
       if (!descriptor) continue;
       for (const dep of descriptor.dependsOn) {
-        if (!formats.includes(dep)) continue;
+        if (!formatSet.has(dep)) continue;
         addEdge(graph, inDegree, dep, format);
       }
     }
@@ -80,15 +84,17 @@ export class GeneratorRegistry {
   }
 }
 
-/** Add a directed edge dep → dependent in the adjacency list. */
+/** Add a directed edge dep → dependent in the adjacency list (idempotent). */
 function addEdge(
-  graph: Map<string, string[]>,
+  graph: Map<string, Set<string>>,
   inDegree: Map<string, number>,
   from: string,
   to: string,
 ): void {
-  if (!graph.has(from)) graph.set(from, []);
-  graph.get(from)!.push(to);
+  if (!graph.has(from)) graph.set(from, new Set());
+  const neighbors = graph.get(from)!;
+  if (neighbors.has(to)) return; // deduplicate edges
+  neighbors.add(to);
   inDegree.set(to, (inDegree.get(to) ?? 0) + 1);
 }
 
@@ -98,7 +104,7 @@ function addEdge(
  */
 function topologicalSort(
   allNodes: string[],
-  graph: Map<string, string[]>,
+  graph: Map<string, Set<string>>,
   inDegree: Map<string, number>,
 ): string[] {
   // Start with nodes that have no incoming edges, sorted for determinism.

--- a/packages/core/src/generators/generator-registry.ts
+++ b/packages/core/src/generators/generator-registry.ts
@@ -1,0 +1,137 @@
+/**
+ * GeneratorRegistry — open registry replacing the hardcoded ALLOWED_FORMATS.
+ *
+ * Per ADR-032 R1 and ADR-034 G3: @mmmnt/core exports the interface +
+ * registry class. Each generator package exports a registerGenerators()
+ * function that populates the registry. The CLI's project-mode bootstrap
+ * calls all of them. No circular dependencies.
+ */
+
+import type { GeneratorDescriptor } from './generator-descriptor.js';
+
+export class GeneratorRegistry {
+  private readonly descriptors = new Map<string, GeneratorDescriptor>();
+
+  /** Register a generator descriptor. Throws if format is already registered. */
+  register(descriptor: GeneratorDescriptor): void {
+    if (this.descriptors.has(descriptor.format)) {
+      throw new Error(`Generator format '${descriptor.format}' is already registered.`);
+    }
+    this.descriptors.set(descriptor.format, descriptor);
+  }
+
+  /** Resolve a descriptor by format name. Throws with available formats if unknown. */
+  resolve(format: string): GeneratorDescriptor {
+    const descriptor = this.descriptors.get(format);
+    if (!descriptor) {
+      const available = [...this.descriptors.keys()].sort().join(', ');
+      throw new Error(
+        `Unknown generator format '${format}'. Registered formats: ${available || '(none)'}`,
+      );
+    }
+    return descriptor;
+  }
+
+  /** Check if a format is registered. */
+  has(format: string): boolean {
+    return this.descriptors.has(format);
+  }
+
+  /** Get all registered descriptors. */
+  getAll(): readonly GeneratorDescriptor[] {
+    return [...this.descriptors.values()];
+  }
+
+  /** Get all registered format names. */
+  getFormats(): readonly string[] {
+    return [...this.descriptors.keys()].sort();
+  }
+
+  /**
+   * Compute a topologically sorted execution order from the dependency
+   * graph declared via dependsOn. Throws on cycles.
+   *
+   * Returns format names in an order where every dependency appears
+   * before its dependent. Independent generators appear in alphabetical
+   * order for determinism.
+   */
+  planExecutionOrder(requestedFormats?: readonly string[]): string[] {
+    const formats = requestedFormats ? [...requestedFormats] : [...this.descriptors.keys()];
+
+    // Build adjacency list from dependsOn edges.
+    const graph = new Map<string, string[]>();
+    const inDegree = new Map<string, number>();
+
+    for (const format of formats) {
+      if (!graph.has(format)) graph.set(format, []);
+      if (!inDegree.has(format)) inDegree.set(format, 0);
+    }
+
+    for (const format of formats) {
+      const descriptor = this.descriptors.get(format);
+      if (!descriptor) continue;
+      for (const dep of descriptor.dependsOn) {
+        if (!formats.includes(dep)) continue;
+        addEdge(graph, inDegree, dep, format);
+      }
+    }
+
+    return topologicalSort(formats, graph, inDegree);
+  }
+}
+
+/** Add a directed edge dep → dependent in the adjacency list. */
+function addEdge(
+  graph: Map<string, string[]>,
+  inDegree: Map<string, number>,
+  from: string,
+  to: string,
+): void {
+  if (!graph.has(from)) graph.set(from, []);
+  graph.get(from)!.push(to);
+  inDegree.set(to, (inDegree.get(to) ?? 0) + 1);
+}
+
+/**
+ * Kahn's algorithm for topological sort. Throws on cycles with a
+ * diagnostic identifying the participants.
+ */
+function topologicalSort(
+  allNodes: string[],
+  graph: Map<string, string[]>,
+  inDegree: Map<string, number>,
+): string[] {
+  // Start with nodes that have no incoming edges, sorted for determinism.
+  const queue = allNodes.filter((n) => (inDegree.get(n) ?? 0) === 0).sort();
+
+  const result: string[] = [];
+
+  while (queue.length > 0) {
+    // Sort queue each iteration to ensure deterministic ordering
+    // among nodes at the same depth level.
+    queue.sort();
+    const node = queue.shift()!;
+    result.push(node);
+
+    for (const neighbor of graph.get(node) ?? []) {
+      const newDegree = (inDegree.get(neighbor) ?? 1) - 1;
+      inDegree.set(neighbor, newDegree);
+      if (newDegree === 0) {
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  if (result.length !== allNodes.length) {
+    const cycleParticipants = allNodes
+      .filter((n) => !result.includes(n))
+      .sort()
+      .join(', ');
+    throw new Error(
+      `Dependency cycle detected among generators: ${cycleParticipants}. ` +
+        `Check the dependsOn declarations for these formats.`,
+    );
+  }
+
+  return result;
+}

--- a/packages/core/src/generators/index.ts
+++ b/packages/core/src/generators/index.ts
@@ -1,0 +1,7 @@
+export { GeneratorRegistry } from './generator-registry.js';
+export type {
+  GeneratorDescriptor,
+  GeneratorRunContext,
+  GeneratorRunResult,
+  GeneratorScope,
+} from './generator-descriptor.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,3 +14,10 @@ export {
 } from './import/index.js';
 export { ProjectLoader, mergeIrs, validateCrossFileReferences } from './project/index.js';
 export type { ProjectLoadResult, MergeResult, CrossFileValidationResult } from './project/index.js';
+export { GeneratorRegistry } from './generators/index.js';
+export type {
+  GeneratorDescriptor,
+  GeneratorRunContext,
+  GeneratorRunResult,
+  GeneratorScope,
+} from './generators/index.js';


### PR DESCRIPTION
## MMNT-5430 — Phase 1.2: Generator Registry

**Jira:** [MMNT-5430](https://winnovation.atlassian.net/browse/MMNT-5430)
**Epic:** [MMNT-5418](https://winnovation.atlassian.net/browse/MMNT-5418)
**ADRs:** ADR-032 R1, ADR-034 G2 + G3

The second Phase 1 foundation piece. Together with #151 (ProjectLoader), this completes the infrastructure needed for project-mode execution.

## What it does

New `GeneratorRegistry` in `@mmmnt/core` that replaces the hardcoded `ALLOWED_FORMATS` set with an open, extensible registry:

```typescript
import { GeneratorRegistry } from '@mmmnt/core';
import type { GeneratorDescriptor } from '@mmmnt/core';

const registry = new GeneratorRegistry();
registry.register({
  format: 'typescript',
  scope: 'project',
  dependsOn: [],
  defaultOutputDir: 'src/generated/ts',
  run: async (ctx) => { /* ... */ },
});

const order = registry.planExecutionOrder();
// ['event-catalog', 'gherkin', 'markdown', 'topology', 'typescript', 'viz',
//  'asyncapi', 'cucumber-json', 'facet', 'impact-analysis', 'saga',
//  'simulation', 'test-scaffold']
```

### Three deliverables

| Module | What |
|---|---|
| **`GeneratorDescriptor`** | Interface: `format`, `scope` (context/flow/project), `dependsOn`, `defaultOutputDir`, `run(ctx) → Promise<GeneratorRunResult>` |
| **`GeneratorRunContext` / `GeneratorRunResult`** | Context provides `ir`, `manifestDir`, `outputDir`, `options`, `upstreamOutputs`. Result returns `files: Map<string, string>` + `diagnostics`. Framework writes with centralized `assertPathWithin`. |
| **`GeneratorRegistry`** | `register()`, `resolve()`, `has()`, `getAll()`, `getFormats()`, `planExecutionOrder()` with Kahn's topological sort + cycle detection |

### Design decisions from ADR-034

- **G2**: Generators return in-memory `Map<string, string>` — they never write to disk. The framework handles writes with `assertPathWithin`.
- **G3**: `@mmmnt/core` exports only the interface + registry class. No concrete descriptors. Each generator package will export `registerGenerators(registry)` (next story wires those up). No circular deps.
- **Determinism**: Independent generators sort alphabetically at each DAG level.

## Test plan

- [x] 343/343 core tests pass (17 new)
- [x] Coverage 98.86% lines / 95.12% branches (above 95% threshold)
- [x] Lint clean, build clean
- [x] Full R1 dependency graph (13 formats) sorts correctly without cycles
- [x] Cycle detection catches A→B→A and self-referencing deps
- [x] Diamond dependency graph (A→B,C→D) resolves correctly
- [ ] CI passes

## Changeset

Minor bump — new public API surface.


[MMNT-5430]: https://winnovation.atlassian.net/browse/MMNT-5430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMNT-5418]: https://winnovation.atlassian.net/browse/MMNT-5418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ